### PR TITLE
Add a legend option to get_plot.py and default it for MM

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ feature_extractions   ["doc2vec", "sbert", "tfidf"]
 impossible_models     [["nb", "doc2vec"], ["nb", "sbert"]]
 ```
 
+A command could look like this:
+```console
+asreview makita template multiple_models -f jobs.bat --classifiers "logistic", "nb" --feature_extractions "tfidf"
+```
+
 ## Advanced usage
 
 ### Create and use custom templates

--- a/README.md
+++ b/README.md
@@ -196,8 +196,10 @@ template. For example, the `get_plot.py` script is added to the generated folder
 when using any template, as it is used to generate the plots. 
 
 Still, `get_plot.py` can be used on its own, as it is a standalone script. To use it,
-use `-s` (source) and `-o` (output) to tweak paths and `--show_legend` to add a
-legend to the plot.
+use `-s` (source) and `-o` (output) to tweak paths.
+
+Adding a legend to the plot can be done with the `-l` or `--show_legend` flag,
+with the labels clustered on any of the following: `'model', 'query_strategy', 'balance_strategy', 'feature_extraction', 'n_instances', 'stop_if', 'n_prior_included', 'n_prior_excluded', 'model_param', 'query_param', 'feature_param', 'balance_param'`
 
 #### Available scripts
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ impossible_models     [["nb", "doc2vec"], ["nb", "sbert"]]
 
 A command could look like this:
 ```console
-asreview makita template multiple_models -f jobs.bat --classifiers "logistic", "nb" --feature_extractions "tfidf"
+asreview makita template multiple_models --classifiers logistic nb --feature_extractions tfidf
 ```
 
 ## Advanced usage

--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ For example, the results from *ASReview datatools* are merged via the script `me
 
 Use `-s`  (source) and `-o` (output) to tweak paths.
 
+Some scripts are added automatically to the folder, as they are part of the
+template. For example, the `get_plot.py` script is added to the generated folder
+when using any template, as it is used to generate the plots. Still,
+`get_plot.py` can be used on its own, as it is a standalone script. To use it,
+use `-s` (source) and `-o` (output) to tweak paths and `--show_legend` to add a legend to the plot.
+
 #### Available scripts
 
 The following scripts are available:

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Still, `get_plot.py` can be used on its own, as it is a standalone script. To us
 use `-s` (source) and `-o` (output) to tweak paths.
 
 Adding a legend to the plot can be done with the `-l` or `--show_legend` flag,
-with the labels clustered on any of the following: `'model', 'query_strategy', 'balance_strategy', 'feature_extraction', 'n_instances', 'stop_if', 'n_prior_included', 'n_prior_excluded', 'model_param', 'query_param', 'feature_param', 'balance_param'`
+with the labels clustered on any of the following: `'filename', 'model', 'query_strategy', 'balance_strategy', 'feature_extraction', 'n_instances', 'stop_if', 'n_prior_included', 'n_prior_excluded', 'model_param', 'query_param', 'feature_param', 'balance_param'`
 
 #### Available scripts
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ feature_extractions   ["doc2vec", "sbert", "tfidf"]
 impossible_models     [["nb", "doc2vec"], ["nb", "sbert"]]
 ```
 
-A command could look like this:
+>Example command: If you want to generate a multiple models template with classifiers `logistic`
+and `nb`, and feature extraction `tfidf`, you can use the following command:
+
 ```console
 asreview makita template multiple_models --classifiers logistic nb --feature_extractions tfidf
 ```

--- a/README.md
+++ b/README.md
@@ -193,9 +193,11 @@ Use `-s`  (source) and `-o` (output) to tweak paths.
 
 Some scripts are added automatically to the folder, as they are part of the
 template. For example, the `get_plot.py` script is added to the generated folder
-when using any template, as it is used to generate the plots. Still,
-`get_plot.py` can be used on its own, as it is a standalone script. To use it,
-use `-s` (source) and `-o` (output) to tweak paths and `--show_legend` to add a legend to the plot.
+when using any template, as it is used to generate the plots. 
+
+Still, `get_plot.py` can be used on its own, as it is a standalone script. To use it,
+use `-s` (source) and `-o` (output) to tweak paths and `--show_legend` to add a
+legend to the plot.
 
 #### Available scripts
 

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -60,5 +60,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # generate plot and save results
-    get_plot_from_states(args.s, args.o, args.l)
+    get_plot_from_states(args.s, args.o, legend=args.show_legend)
 

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -36,7 +36,7 @@ def get_plot_from_states(state_path, filename, legend):
             ax.lines[i*2].set_label(state_file.stem)
 
     if legend:
-        ax.legend()
+        ax.legend(loc=4, prop={'size': 8})
 
     fig.savefig(str(filename))
 

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -53,6 +53,7 @@ def get_plot_from_states(state_path, filename, legend):
 
     fig.savefig(str(filename))
 
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -42,10 +42,11 @@ def get_plot_from_states(state_path, filename, legend):
             # set the label
             if legend and not legend == "filename":
                 metadata = state.settings_metadata
-                if metadata["settings"][legend] not in labels:
-                    ax.lines[-2].set_label(metadata["settings"][legend])
-                    labels.append(metadata["settings"][legend])
-                ax.lines[-2].set_color(colors[labels.index(metadata["settings"][legend]) % len(colors)])
+                label = metadata["settings"][legend]
+                if label not in labels:
+                    ax.lines[-2].set_label(label)
+                    labels.append(label)
+                ax.lines[-2].set_color(colors[labels.index(label) % len(colors)])
                 ax.legend(loc=4, prop={'size': 8})
             elif legend == "filename":
                 ax.lines[-2].set_label(state_file.stem)

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -47,6 +47,9 @@ def get_plot_from_states(state_path, filename, legend):
                     labels.append(metadata["settings"][legend])
                 ax.lines[-2].set_color(colors[labels.index(metadata["settings"][legend])%len(colors)])
                 ax.legend(loc=4, prop={'size': 8})
+            elif legend == "filename":
+                ax.lines[-2].set_label(state_file.stem)
+                ax.legend(loc=4, prop={'size': 8})
 
     fig.savefig(str(filename))
 

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -60,5 +60,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # generate plot and save results
-    get_plot_from_states(args.s, args.o)
+    get_plot_from_states(args.s, args.o, args.l)
 

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -20,23 +20,33 @@ Authors
 import argparse
 from pathlib import Path
 import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
 
 from asreview import open_state
 from asreviewcontrib.insights.plot import plot_recall
 
 
-def get_plot_from_states(state_path, filename, legend=False):
+def get_plot_from_states(state_path, filename, legend):
     """Generate an ASReview plot from state files."""
 
     fig, ax = plt.subplots()
 
-    for i, state_file in enumerate(Path(state_path).glob("*.asreview")):
-        with open_state(state_file) as state:
-            plot_recall(ax, state)
-            ax.lines[i*2].set_label(state_file.stem)
+    labels = []
+    colors = list(mcolors.TABLEAU_COLORS.values())
 
-    if legend:
-        ax.legend(loc=4, prop={'size': 8})
+    for state_file in Path(state_path).glob("*.asreview"):
+        with open_state(state_file) as state:
+            # draw the plot
+            plot_recall(ax, state)
+
+            # set the label
+            if legend:
+                metadata = state.settings_metadata
+                if metadata["settings"][legend] not in labels: 
+                    ax.lines[-2].set_label(metadata["settings"][legend])
+                    labels.append(metadata["settings"][legend])
+                ax.lines[-2].set_color(colors[labels.index(metadata["settings"][legend])%len(colors)])
+                ax.legend(loc=4, prop={'size': 8})
 
     fig.savefig(str(filename))
 
@@ -55,10 +65,10 @@ if __name__ == "__main__":
         help="Output location")
     parser.add_argument(
         "--show_legend", "-l",
-        action='store_true',
-        help="Add a legend to the plot")
+        type=str,
+        help="Add a legend to the plot, based on the given parameter.")
     args = parser.parse_args()
 
     # generate plot and save results
-    get_plot_from_states(args.s, args.o, legend=args.show_legend)
+    get_plot_from_states(args.s, args.o, args.show_legend)
 

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         type=str,
         help="Output location")
     parser.add_argument(
-        "-l",
+        "--show_legend", "-l",
         action='store_true',
         help="Add a legend to the plot")
     args = parser.parse_args()

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -43,6 +43,7 @@ def get_plot_from_states(state_path, filename, legend):
             if legend == "filename":
                 ax.lines[-2].set_label(state_file.stem)
                 ax.legend(loc=4, prop={'size': 8})
+                continue
             
             if legend:
                 metadata = state.settings_metadata

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -40,7 +40,7 @@ def get_plot_from_states(state_path, filename, legend):
             plot_recall(ax, state)
 
             # set the label
-            if legend:
+            if legend and not legend == "filename":
                 metadata = state.settings_metadata
                 if metadata["settings"][legend] not in labels: 
                     ax.lines[-2].set_label(metadata["settings"][legend])

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -43,33 +43,19 @@ def get_plot_from_states(state_path, filename, legend):
             if legend == "filename":
                 ax.lines[-2].set_label(state_file.stem)
                 ax.legend(loc=4, prop={'size': 8})
-
-            elif legend == "model":
+            
+            if legend:
                 metadata = state.settings_metadata
-                label = str(metadata["settings"]["model"] + " - " +
-                            metadata["settings"]["feature_extraction"])
-                if label not in labels:
-                    ax.lines[-2].set_label(label)
-                    labels.append(label)
-                ax.lines[-2].set_color(colors[labels.index(label) % len(colors)])
-                ax.legend(loc=4, prop={'size': 8})
 
-            elif legend == "classifier":
-                metadata = state.settings_metadata
-                label = metadata["settings"]["model"]
-                if label not in labels:
-                    ax.lines[-2].set_label(label)
-                    labels.append(label)
-                ax.lines[-2].set_color(colors[labels.index(label) % len(colors)])
-                ax.legend(loc=4, prop={'size': 8})
-
-            elif legend:
-                metadata = state.settings_metadata
-                # try to get the label from the state file
-                try:
-                    label = metadata["settings"][legend]
-                except KeyError as exc:
-                    raise ValueError(f"Legend {legend} not found in state file settings.") from exc
+                if legend == "model":
+                    label = metadata["settings"]["model"] + " - " + metadata["settings"]["feature_extraction"]
+                elif legend == "classifier":
+                    label = metadata["settings"]["model"]
+                else:
+                    try:
+                        label = metadata["settings"][legend]
+                    except KeyError as exc:
+                        raise ValueError(f"Legend setting '{legend}' not found in state file settings.") from exc
                 if label not in labels:
                     ax.lines[-2].set_label(label)
                     labels.append(label)

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -40,16 +40,40 @@ def get_plot_from_states(state_path, filename, legend):
             plot_recall(ax, state)
 
             # set the label
-            if legend and not legend == "filename":
+            if legend == "filename":
+                ax.lines[-2].set_label(state_file.stem)
+                ax.legend(loc=4, prop={'size': 8})
+
+            elif legend == "model":
                 metadata = state.settings_metadata
-                label = metadata["settings"][legend]
+                label = str(metadata["settings"]["model"] + " - " +
+                            metadata["settings"]["feature_extraction"])
                 if label not in labels:
                     ax.lines[-2].set_label(label)
                     labels.append(label)
                 ax.lines[-2].set_color(colors[labels.index(label) % len(colors)])
                 ax.legend(loc=4, prop={'size': 8})
-            elif legend == "filename":
-                ax.lines[-2].set_label(state_file.stem)
+
+            elif legend == "classifier":
+                metadata = state.settings_metadata
+                label = metadata["settings"]["model"]
+                if label not in labels:
+                    ax.lines[-2].set_label(label)
+                    labels.append(label)
+                ax.lines[-2].set_color(colors[labels.index(label) % len(colors)])
+                ax.legend(loc=4, prop={'size': 8})
+
+            elif legend:
+                metadata = state.settings_metadata
+                # try to get the label from the state file
+                try:
+                    label = metadata["settings"][legend]
+                except KeyError as exc:
+                    raise ValueError(f"Legend {legend} not found in state file settings.") from exc
+                if label not in labels:
+                    ax.lines[-2].set_label(label)
+                    labels.append(label)
+                ax.lines[-2].set_color(colors[labels.index(label) % len(colors)])
                 ax.legend(loc=4, prop={'size': 8})
 
     fig.savefig(str(filename))

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -45,7 +45,7 @@ def get_plot_from_states(state_path, filename, legend):
                 if metadata["settings"][legend] not in labels: 
                     ax.lines[-2].set_label(metadata["settings"][legend])
                     labels.append(metadata["settings"][legend])
-                ax.lines[-2].set_color(colors[labels.index(metadata["settings"][legend])%len(colors)])
+                ax.lines[-2].set_color(colors[labels.index(metadata["settings"][legend]) % len(colors)])
                 ax.legend(loc=4, prop={'size': 8})
             elif legend == "filename":
                 ax.lines[-2].set_label(state_file.stem)

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -25,17 +25,20 @@ from asreview import open_state
 from asreviewcontrib.insights.plot import plot_recall
 
 
-def get_plot_from_states(state_path, filename):
+def get_plot_from_states(state_path, filename, legend):
     """Generate an ASReview plot from state files."""
 
     fig, ax = plt.subplots()
 
-    for state_file in Path(state_path).glob("*.asreview"):
+    for i, state_file in enumerate(Path(state_path).glob("*.asreview")):
         with open_state(state_file) as state:
             plot_recall(ax, state)
+            ax.lines[i*2].set_label(state_file.stem)
+
+    if legend:
+        ax.legend()
 
     fig.savefig(str(filename))
-
 
 if __name__ == "__main__":
 
@@ -50,6 +53,10 @@ if __name__ == "__main__":
         "-o",
         type=str,
         help="Output location")
+    parser.add_argument(
+        "-l",
+        action='store_true',
+        help="Add a legend to the plot")
     args = parser.parse_args()
 
     # generate plot and save results

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -25,7 +25,7 @@ from asreview import open_state
 from asreviewcontrib.insights.plot import plot_recall
 
 
-def get_plot_from_states(state_path, filename, legend):
+def get_plot_from_states(state_path, filename, legend=False):
     """Generate an ASReview plot from state files."""
 
     fig, ax = plt.subplots()

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -42,7 +42,7 @@ def get_plot_from_states(state_path, filename, legend):
             # set the label
             if legend and not legend == "filename":
                 metadata = state.settings_metadata
-                if metadata["settings"][legend] not in labels: 
+                if metadata["settings"][legend] not in labels:
                     ax.lines[-2].set_label(metadata["settings"][legend])
                     labels.append(metadata["settings"][legend])
                 ax.lines[-2].set_color(colors[labels.index(metadata["settings"][legend]) % len(colors)])

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -50,7 +50,7 @@ asreview metrics {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/st
 {% endfor %}
 
 # Generate plot for dataset
-python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png
+python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png -l
 {% endfor %}
 
 # Merge descriptives and metrics

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -50,7 +50,7 @@ asreview metrics {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/st
 {% endfor %}
 
 # Generate plot for dataset
-python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png -l
+python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png --show_legend
 {% endfor %}
 
 # Merge descriptives and metrics

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -50,7 +50,7 @@ asreview metrics {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/st
 {% endfor %}
 
 # Generate plot for dataset
-python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png --show_legend
+python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png --show_legend model
 {% endfor %}
 
 # Merge descriptives and metrics


### PR DESCRIPTION
This PR will add the option to get_plot to add a legend to the plot. The legend names are based on the state_file name.

I've shrunk the legend to avoid overlaps with the plot.

![image](https://user-images.githubusercontent.com/28191416/199218317-13258805-79a0-4273-abad-42983c76a3df.png)

Adding a legend is done by adding the `-l` flag to the `get_plot.py` script. This is set by default for the multiple models template.

Based on issue #3 