### PR TITLE
Update multiple models template and add legends to plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ feature_extractions   ["doc2vec", "sbert", "tfidf"]
 impossible_models     [["nb", "doc2vec"], ["nb", "sbert"]]
 ```
 
+A command could look like this:
+```console
+asreview makita template multiple_models -f jobs.bat --classifiers "logistic", "nb" --feature_extractions "tfidf"
+```
+
 ## Advanced usage
 
 ### Create and use custom templates

--- a/README.md
+++ b/README.md
@@ -196,8 +196,10 @@ template. For example, the `get_plot.py` script is added to the generated folder
 when using any template, as it is used to generate the plots. 
 
 Still, `get_plot.py` can be used on its own, as it is a standalone script. To use it,
-use `-s` (source) and `-o` (output) to tweak paths and `--show_legend` to add a
-legend to the plot.
+use `-s` (source) and `-o` (output) to tweak paths.
+
+Adding a legend to the plot can be done with the `-l` or `--show_legend` flag,
+with the labels clustered on any of the following: `'model', 'query_strategy', 'balance_strategy', 'feature_extraction', 'n_instances', 'stop_if', 'n_prior_included', 'n_prior_excluded', 'model_param', 'query_param', 'feature_param', 'balance_param'`
 
 #### Available scripts
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ optional arguments:
   --model_seed MODEL_SEED                          Seed of the models. Seed is set by default!
   --template TEMPLATE                              Overwrite template with template file path.
   --classifiers CLASSIFIERS [CLASSIFIERS ...]                           Classifiers to use
-  --feature_extraction FEATURE_EXTRACTION [FEATURE_EXTRACTION ...]   Feature extractions to use
+  --feature_extractions FEATURE_EXTRACTIONS [FEATURE_EXTRACTIONS ...]   Feature extractions to use
   --impossible_models IMPOSSIBLE_MODELS [IMPOSSIBLE_MODELS ...]         Model combinations to exclude
 ```
 
@@ -147,7 +147,7 @@ The default models are:
 
 ```python
 classifiers           ["logistic", "nb", "rf", "svm"]
-feature_extraction   ["doc2vec", "sbert", "tfidf"]
+feature_extractions   ["doc2vec", "sbert", "tfidf"]
 impossible_models     [["nb", "doc2vec"], ["nb", "sbert"]]
 ```
 
@@ -155,7 +155,7 @@ impossible_models     [["nb", "doc2vec"], ["nb", "sbert"]]
 and `nb`, and feature extraction `tfidf`, you can use the following command:
 
 ```console
-asreview makita template multiple_models --classifiers logistic nb --feature_extraction tfidf
+asreview makita template multiple_models --classifiers logistic nb --feature_extractions tfidf
 ```
 
 ## Advanced usage

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ optional arguments:
   --model_seed MODEL_SEED                          Seed of the models. Seed is set by default!
   --template TEMPLATE                              Overwrite template with template file path.
   --classifiers CLASSIFIERS [CLASSIFIERS ...]                           Classifiers to use
-  --feature_extractions FEATURE_EXTRACTIONS [FEATURE_EXTRACTIONS ...]   Feature extractions to use
+  --feature_extraction FEATURE_EXTRACTION [FEATURE_EXTRACTION ...]   Feature extractions to use
   --impossible_models IMPOSSIBLE_MODELS [IMPOSSIBLE_MODELS ...]         Model combinations to exclude
 ```
 
@@ -147,7 +147,7 @@ The default models are:
 
 ```python
 classifiers           ["logistic", "nb", "rf", "svm"]
-feature_extractions   ["doc2vec", "sbert", "tfidf"]
+feature_extraction   ["doc2vec", "sbert", "tfidf"]
 impossible_models     [["nb", "doc2vec"], ["nb", "sbert"]]
 ```
 
@@ -155,7 +155,7 @@ impossible_models     [["nb", "doc2vec"], ["nb", "sbert"]]
 and `nb`, and feature extraction `tfidf`, you can use the following command:
 
 ```console
-asreview makita template multiple_models --classifiers logistic nb --feature_extractions tfidf
+asreview makita template multiple_models --classifiers logistic nb --feature_extraction tfidf
 ```
 
 ## Advanced usage

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ impossible_models     [["nb", "doc2vec"], ["nb", "sbert"]]
 
 A command could look like this:
 ```console
-asreview makita template multiple_models -f jobs.bat --classifiers "logistic", "nb" --feature_extractions "tfidf"
+asreview makita template multiple_models --classifiers logistic nb --feature_extractions tfidf
 ```
 
 ## Advanced usage

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ optional arguments:
   --model_seed MODEL_SEED                          Seed of the models. Seed is set by default!
   --template TEMPLATE                              Overwrite template with template file path.
   --classifiers CLASSIFIERS [CLASSIFIERS ...]                           Classifiers to use
-  --feature_extractions FEATURE_EXTRACTIONS [FEATURE_EXTRACTIONS ...]   Feature extractions to use
+  --feature_extractors FEATURE_EXTRACTOR [FEATURE_EXTRACTORS ...]   Feature extractors to use
   --impossible_models IMPOSSIBLE_MODELS [IMPOSSIBLE_MODELS ...]         Model combinations to exclude
 ```
 
@@ -147,7 +147,7 @@ The default models are:
 
 ```python
 classifiers           ["logistic", "nb", "rf", "svm"]
-feature_extractions   ["doc2vec", "sbert", "tfidf"]
+feature_extractors   ["doc2vec", "sbert", "tfidf"]
 impossible_models     [["nb", "doc2vec"], ["nb", "sbert"]]
 ```
 
@@ -155,7 +155,7 @@ impossible_models     [["nb", "doc2vec"], ["nb", "sbert"]]
 and `nb`, and feature extraction `tfidf`, you can use the following command:
 
 ```console
-asreview makita template multiple_models --classifiers logistic nb --feature_extractions tfidf
+asreview makita template multiple_models --classifiers logistic nb --feature_extractors tfidf
 ```
 
 ## Advanced usage

--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ For example, the results from *ASReview datatools* are merged via the script `me
 
 Use `-s`  (source) and `-o` (output) to tweak paths.
 
+Some scripts are added automatically to the folder, as they are part of the
+template. For example, the `get_plot.py` script is added to the generated folder
+when using any template, as it is used to generate the plots. Still,
+`get_plot.py` can be used on its own, as it is a standalone script. To use it,
+use `-s` (source) and `-o` (output) to tweak paths and `--show_legend` to add a legend to the plot.
+
 #### Available scripts
 
 The following scripts are available:

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Still, `get_plot.py` can be used on its own, as it is a standalone script. To us
 use `-s` (source) and `-o` (output) to tweak paths.
 
 Adding a legend to the plot can be done with the `-l` or `--show_legend` flag,
-with the labels clustered on any of the following: `'model', 'query_strategy', 'balance_strategy', 'feature_extraction', 'n_instances', 'stop_if', 'n_prior_included', 'n_prior_excluded', 'model_param', 'query_param', 'feature_param', 'balance_param'`
+with the labels clustered on any of the following: `'filename', 'model', 'query_strategy', 'balance_strategy', 'feature_extraction', 'n_instances', 'stop_if', 'n_prior_included', 'n_prior_excluded', 'model_param', 'query_param', 'feature_param', 'balance_param'`
 
 #### Available scripts
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ feature_extractions   ["doc2vec", "sbert", "tfidf"]
 impossible_models     [["nb", "doc2vec"], ["nb", "sbert"]]
 ```
 
-A command could look like this:
+>Example command: If you want to generate a multiple models template with classifiers `logistic`
+and `nb`, and feature extraction `tfidf`, you can use the following command:
+
 ```console
 asreview makita template multiple_models --classifiers logistic nb --feature_extractions tfidf
 ```

--- a/README.md
+++ b/README.md
@@ -193,9 +193,11 @@ Use `-s`  (source) and `-o` (output) to tweak paths.
 
 Some scripts are added automatically to the folder, as they are part of the
 template. For example, the `get_plot.py` script is added to the generated folder
-when using any template, as it is used to generate the plots. Still,
-`get_plot.py` can be used on its own, as it is a standalone script. To use it,
-use `-s` (source) and `-o` (output) to tweak paths and `--show_legend` to add a legend to the plot.
+when using any template, as it is used to generate the plots. 
+
+Still, `get_plot.py` can be used on its own, as it is a standalone script. To use it,
+use `-s` (source) and `-o` (output) to tweak paths and `--show_legend` to add a
+legend to the plot.
 
 #### Available scripts
 

--- a/asreviewcontrib/makita/entrypoint.py
+++ b/asreviewcontrib/makita/entrypoint.py
@@ -95,7 +95,7 @@ class MakitaEntryPoint(BaseEntryPoint):
                                 default=["logistic", "nb", "rf", "svm"],
                                 help="Classifiers to use"
                                 )
-            parser.add_argument("--feature_extraction",
+            parser.add_argument("--feature_extractors",
                                 nargs="+",
                                 default=["doc2vec", "sbert", "tfidf"],
                                 help="Feature extractors to use"
@@ -153,7 +153,7 @@ class MakitaEntryPoint(BaseEntryPoint):
                 init_seed=args.init_seed,
                 model_seed=args.model_seed,
                 all_classifiers=args.classifiers,
-                all_feature_extraction=args.feature_extraction,
+                all_feature_extractors=args.feature_extractors,
                 impossible_models=args.impossible_models,
                 fp_template=fp_template,
                 job_file=args.f,

--- a/asreviewcontrib/makita/entrypoint.py
+++ b/asreviewcontrib/makita/entrypoint.py
@@ -30,7 +30,7 @@ def _valid_job_file(param):
     return param
 
 
-def shell_to_batch(job):
+def _shell_to_batch(job):
     job = f'@ echo off\nCOLOR E0{job}'
     job = job.replace('#', '::')
     job = job.replace('/', '\\')
@@ -171,7 +171,7 @@ class MakitaEntryPoint(BaseEntryPoint):
             )
 
         if Path(args.f).suffix.lower() == '.bat':
-            job = shell_to_batch(job)
+            job = _shell_to_batch(job)
 
         # store result in output folder
         Path(args.f).parent.mkdir(parents=True, exist_ok=True)

--- a/asreviewcontrib/makita/entrypoint.py
+++ b/asreviewcontrib/makita/entrypoint.py
@@ -95,7 +95,7 @@ class MakitaEntryPoint(BaseEntryPoint):
                                 default=["logistic", "nb", "rf", "svm"],
                                 help="Classifiers to use"
                                 )
-            parser.add_argument("--feature_extractors",
+            parser.add_argument("--feature_extraction",
                                 nargs="+",
                                 default=["doc2vec", "sbert", "tfidf"],
                                 help="Feature extractors to use"
@@ -153,7 +153,7 @@ class MakitaEntryPoint(BaseEntryPoint):
                 init_seed=args.init_seed,
                 model_seed=args.model_seed,
                 all_classifiers=args.classifiers,
-                all_feature_extractors=args.feature_extractors,
+                all_feature_extraction=args.feature_extraction,
                 impossible_models=args.impossible_models,
                 fp_template=fp_template,
                 job_file=args.f,

--- a/asreviewcontrib/makita/entrypoint.py
+++ b/asreviewcontrib/makita/entrypoint.py
@@ -77,7 +77,7 @@ class MakitaEntryPoint(BaseEntryPoint):
         parser = _parse_arguments_template(self.version)
 
         # template specific arguments
-        if args_program.name in ["basic"]:
+        if args_program.name in ["basic", "multiple_models"]:
             parser.add_argument("--n_runs",
                                 type=int,
                                 default=1,
@@ -95,10 +95,10 @@ class MakitaEntryPoint(BaseEntryPoint):
                                 default=["logistic", "nb", "rf", "svm"],
                                 help="Classifiers to use"
                                 )
-            parser.add_argument("--feature_extractions",
+            parser.add_argument("--feature_extractors",
                                 nargs="+",
                                 default=["doc2vec", "sbert", "tfidf"],
-                                help="Feature extractions to use"
+                                help="Feature extractors to use"
                                 )
             parser.add_argument("--impossible_models",
                                 nargs="+",
@@ -149,10 +149,11 @@ class MakitaEntryPoint(BaseEntryPoint):
             job = render_jobs_multiple_models(
                 datasets,
                 output_folder=Path(args.o),
+                n_runs=args.n_runs,
                 init_seed=args.init_seed,
                 model_seed=args.model_seed,
                 all_classifiers=args.classifiers,
-                all_feature_extractions=args.feature_extractions,
+                all_feature_extractors=args.feature_extractors,
                 impossible_models=args.impossible_models,
                 fp_template=fp_template,
                 job_file=args.f,

--- a/asreviewcontrib/makita/template_multiple_models.py
+++ b/asreviewcontrib/makita/template_multiple_models.py
@@ -18,7 +18,7 @@ def render_jobs_multiple_models(
     init_seed=535,
     model_seed=165,
     all_classifiers=["logistic", "nb", "rf", "svm"],
-    all_feature_extraction=["doc2vec", "sbert", "tfidf"],
+    all_feature_extractors=["doc2vec", "sbert", "tfidf"],
     impossible_models=[["nb", "doc2vec"], ["nb", "sbert"]],
     fp_template=None,
     job_file='jobs.sh',
@@ -70,7 +70,7 @@ def render_jobs_multiple_models(
             "scripts_folder": scripts_folder,
             "version": __version__,
             "all_classifiers": all_classifiers,
-            "all_feature_extraction": all_feature_extraction,
+            "all_feature_extractors": all_feature_extractors,
             "impossible_models": impossible_models,
         }
     )

--- a/asreviewcontrib/makita/template_multiple_models.py
+++ b/asreviewcontrib/makita/template_multiple_models.py
@@ -18,7 +18,7 @@ def render_jobs_multiple_models(
     init_seed=535,
     model_seed=165,
     all_classifiers=["logistic", "nb", "rf", "svm"],
-    all_feature_extractors=["doc2vec", "sbert", "tfidf"],
+    all_feature_extraction=["doc2vec", "sbert", "tfidf"],
     impossible_models=[["nb", "doc2vec"], ["nb", "sbert"]],
     fp_template=None,
     job_file='jobs.sh',
@@ -70,7 +70,7 @@ def render_jobs_multiple_models(
             "scripts_folder": scripts_folder,
             "version": __version__,
             "all_classifiers": all_classifiers,
-            "all_feature_extractors": all_feature_extractors,
+            "all_feature_extraction": all_feature_extraction,
             "impossible_models": impossible_models,
         }
     )

--- a/asreviewcontrib/makita/template_multiple_models.py
+++ b/asreviewcontrib/makita/template_multiple_models.py
@@ -13,11 +13,12 @@ from asreviewcontrib.makita.utils import get_file
 def render_jobs_multiple_models(
     datasets,
     output_folder="output",
+    n_runs=1,
     scripts_folder="scripts",
     init_seed=535,
     model_seed=165,
     all_classifiers=["logistic", "nb", "rf", "svm"],
-    all_feature_extractions=["doc2vec", "sbert", "tfidf"],
+    all_feature_extractors=["doc2vec", "sbert", "tfidf"],
     impossible_models=[["nb", "doc2vec"], ["nb", "sbert"]],
     fp_template=None,
     job_file='jobs.sh',
@@ -65,10 +66,11 @@ def render_jobs_multiple_models(
         {
             "datasets": params,
             "output_folder": output_folder,
+            "n_runs": n_runs,
             "scripts_folder": scripts_folder,
             "version": __version__,
             "all_classifiers": all_classifiers,
-            "all_feature_extractions": all_feature_extractions,
+            "all_feature_extractors": all_feature_extractors,
             "impossible_models": impossible_models,
         }
     )

--- a/asreviewcontrib/makita/templates/doc_README.md.template
+++ b/asreviewcontrib/makita/templates/doc_README.md.template
@@ -28,7 +28,7 @@ The performance on the following datasets is evaluated:
 sh jobs.sh
 ```{% else %}To start the simulation, run the `{{ job_file }}` file.{% endif %}
 
-{% if template_name != 'custom' %}## structure
+{% if template_name != 'custom' %}## Structure
 
 The following files are found in this project:
 

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -60,5 +60,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # generate plot and save results
-    get_plot_from_states(args.s, args.o, args.l)
+    get_plot_from_states(args.s, args.o, legend=args.show_legend)
 

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -36,7 +36,7 @@ def get_plot_from_states(state_path, filename, legend):
             ax.lines[i*2].set_label(state_file.stem)
 
     if legend:
-        ax.legend()
+        ax.legend(loc=4, prop={'size': 8})
 
     fig.savefig(str(filename))
 

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -53,6 +53,7 @@ def get_plot_from_states(state_path, filename, legend):
 
     fig.savefig(str(filename))
 
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -42,10 +42,11 @@ def get_plot_from_states(state_path, filename, legend):
             # set the label
             if legend and not legend == "filename":
                 metadata = state.settings_metadata
-                if metadata["settings"][legend] not in labels:
-                    ax.lines[-2].set_label(metadata["settings"][legend])
-                    labels.append(metadata["settings"][legend])
-                ax.lines[-2].set_color(colors[labels.index(metadata["settings"][legend]) % len(colors)])
+                label = metadata["settings"][legend]
+                if label not in labels:
+                    ax.lines[-2].set_label(label)
+                    labels.append(label)
+                ax.lines[-2].set_color(colors[labels.index(label) % len(colors)])
                 ax.legend(loc=4, prop={'size': 8})
             elif legend == "filename":
                 ax.lines[-2].set_label(state_file.stem)

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -47,6 +47,9 @@ def get_plot_from_states(state_path, filename, legend):
                     labels.append(metadata["settings"][legend])
                 ax.lines[-2].set_color(colors[labels.index(metadata["settings"][legend])%len(colors)])
                 ax.legend(loc=4, prop={'size': 8})
+            elif legend == "filename":
+                ax.lines[-2].set_label(state_file.stem)
+                ax.legend(loc=4, prop={'size': 8})
 
     fig.savefig(str(filename))
 

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -60,5 +60,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # generate plot and save results
-    get_plot_from_states(args.s, args.o)
+    get_plot_from_states(args.s, args.o, args.l)
 

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -20,23 +20,33 @@ Authors
 import argparse
 from pathlib import Path
 import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
 
 from asreview import open_state
 from asreviewcontrib.insights.plot import plot_recall
 
 
-def get_plot_from_states(state_path, filename, legend=False):
+def get_plot_from_states(state_path, filename, legend):
     """Generate an ASReview plot from state files."""
 
     fig, ax = plt.subplots()
 
-    for i, state_file in enumerate(Path(state_path).glob("*.asreview")):
-        with open_state(state_file) as state:
-            plot_recall(ax, state)
-            ax.lines[i*2].set_label(state_file.stem)
+    labels = []
+    colors = list(mcolors.TABLEAU_COLORS.values())
 
-    if legend:
-        ax.legend(loc=4, prop={'size': 8})
+    for state_file in Path(state_path).glob("*.asreview"):
+        with open_state(state_file) as state:
+            # draw the plot
+            plot_recall(ax, state)
+
+            # set the label
+            if legend:
+                metadata = state.settings_metadata
+                if metadata["settings"][legend] not in labels: 
+                    ax.lines[-2].set_label(metadata["settings"][legend])
+                    labels.append(metadata["settings"][legend])
+                ax.lines[-2].set_color(colors[labels.index(metadata["settings"][legend])%len(colors)])
+                ax.legend(loc=4, prop={'size': 8})
 
     fig.savefig(str(filename))
 
@@ -55,10 +65,10 @@ if __name__ == "__main__":
         help="Output location")
     parser.add_argument(
         "--show_legend", "-l",
-        action='store_true',
-        help="Add a legend to the plot")
+        type=str,
+        help="Add a legend to the plot, based on the given parameter.")
     args = parser.parse_args()
 
     # generate plot and save results
-    get_plot_from_states(args.s, args.o, legend=args.show_legend)
+    get_plot_from_states(args.s, args.o, args.show_legend)
 

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         type=str,
         help="Output location")
     parser.add_argument(
-        "-l",
+        "--show_legend", "-l",
         action='store_true',
         help="Add a legend to the plot")
     args = parser.parse_args()

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -40,7 +40,7 @@ def get_plot_from_states(state_path, filename, legend):
             plot_recall(ax, state)
 
             # set the label
-            if legend:
+            if legend and not legend == "filename":
                 metadata = state.settings_metadata
                 if metadata["settings"][legend] not in labels: 
                     ax.lines[-2].set_label(metadata["settings"][legend])

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -43,33 +43,19 @@ def get_plot_from_states(state_path, filename, legend):
             if legend == "filename":
                 ax.lines[-2].set_label(state_file.stem)
                 ax.legend(loc=4, prop={'size': 8})
-
-            elif legend == "model":
+            
+            if legend:
                 metadata = state.settings_metadata
-                label = str(metadata["settings"]["model"] + " - " +
-                            metadata["settings"]["feature_extraction"])
-                if label not in labels:
-                    ax.lines[-2].set_label(label)
-                    labels.append(label)
-                ax.lines[-2].set_color(colors[labels.index(label) % len(colors)])
-                ax.legend(loc=4, prop={'size': 8})
 
-            elif legend == "classifier":
-                metadata = state.settings_metadata
-                label = metadata["settings"]["model"]
-                if label not in labels:
-                    ax.lines[-2].set_label(label)
-                    labels.append(label)
-                ax.lines[-2].set_color(colors[labels.index(label) % len(colors)])
-                ax.legend(loc=4, prop={'size': 8})
-
-            elif legend:
-                metadata = state.settings_metadata
-                # try to get the label from the state file
-                try:
-                    label = metadata["settings"][legend]
-                except KeyError as exc:
-                    raise ValueError(f"Legend {legend} not found in state file settings.") from exc
+                if legend == "model":
+                    label = metadata["settings"]["model"] + " - " + metadata["settings"]["feature_extraction"]
+                elif legend == "classifier":
+                    label = metadata["settings"]["model"]
+                else:
+                    try:
+                        label = metadata["settings"][legend]
+                    except KeyError as exc:
+                        raise ValueError(f"Legend setting '{legend}' not found in state file settings.") from exc
                 if label not in labels:
                     ax.lines[-2].set_label(label)
                     labels.append(label)

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -40,16 +40,40 @@ def get_plot_from_states(state_path, filename, legend):
             plot_recall(ax, state)
 
             # set the label
-            if legend and not legend == "filename":
+            if legend == "filename":
+                ax.lines[-2].set_label(state_file.stem)
+                ax.legend(loc=4, prop={'size': 8})
+
+            elif legend == "model":
                 metadata = state.settings_metadata
-                label = metadata["settings"][legend]
+                label = str(metadata["settings"]["model"] + " - " +
+                            metadata["settings"]["feature_extraction"])
                 if label not in labels:
                     ax.lines[-2].set_label(label)
                     labels.append(label)
                 ax.lines[-2].set_color(colors[labels.index(label) % len(colors)])
                 ax.legend(loc=4, prop={'size': 8})
-            elif legend == "filename":
-                ax.lines[-2].set_label(state_file.stem)
+
+            elif legend == "classifier":
+                metadata = state.settings_metadata
+                label = metadata["settings"]["model"]
+                if label not in labels:
+                    ax.lines[-2].set_label(label)
+                    labels.append(label)
+                ax.lines[-2].set_color(colors[labels.index(label) % len(colors)])
+                ax.legend(loc=4, prop={'size': 8})
+
+            elif legend:
+                metadata = state.settings_metadata
+                # try to get the label from the state file
+                try:
+                    label = metadata["settings"][legend]
+                except KeyError as exc:
+                    raise ValueError(f"Legend {legend} not found in state file settings.") from exc
+                if label not in labels:
+                    ax.lines[-2].set_label(label)
+                    labels.append(label)
+                ax.lines[-2].set_color(colors[labels.index(label) % len(colors)])
                 ax.legend(loc=4, prop={'size': 8})
 
     fig.savefig(str(filename))

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -45,7 +45,7 @@ def get_plot_from_states(state_path, filename, legend):
                 if metadata["settings"][legend] not in labels: 
                     ax.lines[-2].set_label(metadata["settings"][legend])
                     labels.append(metadata["settings"][legend])
-                ax.lines[-2].set_color(colors[labels.index(metadata["settings"][legend])%len(colors)])
+                ax.lines[-2].set_color(colors[labels.index(metadata["settings"][legend]) % len(colors)])
                 ax.legend(loc=4, prop={'size': 8})
             elif legend == "filename":
                 ax.lines[-2].set_label(state_file.stem)

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -47,10 +47,11 @@ def get_plot_from_states(state_path, filename, legend=None):
                 metadata = state.settings_metadata
 
                 if legend == "model":
-                    label = metadata["settings"]["model"] + " - " +\
-                            metadata["settings"]["feature_extraction"] +\
-                            " - " + metadata["settings"]["balance_strategy"] +\
-                            " - " + metadata["settings"]["query_strategy"]
+                    label = " - ".join(
+                            [metadata["settings"]["model"],
+                             metadata["settings"]["feature_extraction"],
+                             metadata["settings"]["balance_strategy"],
+                             metadata["settings"]["query_strategy"]])
                 elif legend == "classifier":
                     label = metadata["settings"]["model"]
                 else:

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -47,7 +47,10 @@ def get_plot_from_states(state_path, filename, legend):
                 metadata = state.settings_metadata
 
                 if legend == "model":
-                    label = metadata["settings"]["model"] + " - " + metadata["settings"]["feature_extraction"]
+                    label = metadata["settings"]["model"] + " - " +\
+                            metadata["settings"]["feature_extraction"] +\
+                            " - " + metadata["settings"]["balance_strategy"] +\
+                            " - " + metadata["settings"]["query_strategy"]
                 elif legend == "classifier":
                     label = metadata["settings"]["model"]
                 else:

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -43,9 +43,7 @@ def get_plot_from_states(state_path, filename, legend):
             if legend == "filename":
                 ax.lines[-2].set_label(state_file.stem)
                 ax.legend(loc=4, prop={'size': 8})
-                continue
-            
-            if legend:
+            elif legend:
                 metadata = state.settings_metadata
 
                 if legend == "model":

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -25,17 +25,20 @@ from asreview import open_state
 from asreviewcontrib.insights.plot import plot_recall
 
 
-def get_plot_from_states(state_path, filename):
+def get_plot_from_states(state_path, filename, legend):
     """Generate an ASReview plot from state files."""
 
     fig, ax = plt.subplots()
 
-    for state_file in Path(state_path).glob("*.asreview"):
+    for i, state_file in enumerate(Path(state_path).glob("*.asreview")):
         with open_state(state_file) as state:
             plot_recall(ax, state)
+            ax.lines[i*2].set_label(state_file.stem)
+
+    if legend:
+        ax.legend()
 
     fig.savefig(str(filename))
-
 
 if __name__ == "__main__":
 
@@ -50,6 +53,10 @@ if __name__ == "__main__":
         "-o",
         type=str,
         help="Output location")
+    parser.add_argument(
+        "-l",
+        action='store_true',
+        help="Add a legend to the plot")
     args = parser.parse_args()
 
     # generate plot and save results

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -25,7 +25,7 @@ from asreview import open_state
 from asreviewcontrib.insights.plot import plot_recall
 
 
-def get_plot_from_states(state_path, filename, legend):
+def get_plot_from_states(state_path, filename, legend=False):
     """Generate an ASReview plot from state files."""
 
     fig, ax = plt.subplots()

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -42,7 +42,7 @@ def get_plot_from_states(state_path, filename, legend):
             # set the label
             if legend and not legend == "filename":
                 metadata = state.settings_metadata
-                if metadata["settings"][legend] not in labels: 
+                if metadata["settings"][legend] not in labels:
                     ax.lines[-2].set_label(metadata["settings"][legend])
                     labels.append(metadata["settings"][legend])
                 ax.lines[-2].set_color(colors[labels.index(metadata["settings"][legend]) % len(colors)])

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -26,7 +26,7 @@ from asreview import open_state
 from asreviewcontrib.insights.plot import plot_recall
 
 
-def get_plot_from_states(state_path, filename, legend):
+def get_plot_from_states(state_path, filename, legend=None):
     """Generate an ASReview plot from state files."""
 
     fig, ax = plt.subplots()

--- a/asreviewcontrib/makita/templates/template_arfi.txt.template
+++ b/asreviewcontrib/makita/templates/template_arfi.txt.template
@@ -44,7 +44,7 @@ asreview metrics {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/st
 {% endfor %}
 
 # Generate plot for dataset
-python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png
+python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png --show_legend filename
 {% endfor %}
 
 # Merge descriptives and metrics

--- a/asreviewcontrib/makita/templates/template_arfi.txt.template
+++ b/asreviewcontrib/makita/templates/template_arfi.txt.template
@@ -44,7 +44,7 @@ asreview metrics {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/st
 {% endfor %}
 
 # Generate plot for dataset
-python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png --show_legend filename
+python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png
 {% endfor %}
 
 # Merge descriptives and metrics

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -38,7 +38,7 @@ asreview wordcloud {{ dataset.input_file }} -o {{ output_folder }}/simulation/{{
 # Simulate runs
 mkdir {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files
 {% for classifier in all_classifiers %}
-{% for feature_extraction in all_feature_extraction %}
+{% for feature_extraction in all_feature_extractors %}
 {% set temp = [] %}{{ temp.append(classifier)|default("", True) }}{{ temp.append(feature_extraction)|default("", True) }}
 {% if temp in impossible_models %}
 # Skipped {{ classifier }} + {{ feature_extraction }} model

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -38,7 +38,7 @@ asreview wordcloud {{ dataset.input_file }} -o {{ output_folder }}/simulation/{{
 # Simulate runs
 mkdir {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files
 {% for classifier in all_classifiers %}
-{% for feature_extraction in all_feature_extractors %}
+{% for feature_extraction in all_feature_extraction %}
 {% set temp = [] %}{{ temp.append(classifier)|default("", True) }}{{ temp.append(feature_extraction)|default("", True) }}
 {% if temp in impossible_models %}
 # Skipped {{ classifier }} + {{ feature_extraction }} model

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -50,7 +50,7 @@ asreview metrics {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/st
 {% endfor %}
 
 # Generate plot for dataset
-python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png
+python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png -l
 {% endfor %}
 
 # Merge descriptives and metrics

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -50,7 +50,7 @@ asreview metrics {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/st
 {% endfor %}
 
 # Generate plot for dataset
-python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png -l
+python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png --show_legend
 {% endfor %}
 
 # Merge descriptives and metrics

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -38,14 +38,9 @@ asreview wordcloud {{ dataset.input_file }} -o {{ output_folder }}/simulation/{{
 # Simulate runs
 mkdir {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files
 {% for classifier in all_classifiers %}
-{% for feature_extraction in all_feature_extractions %}
+{% for feature_extraction in all_feature_extractors %}
 {% set temp = [] %}{{ temp.append(classifier)|default("", True) }}{{ temp.append(feature_extraction)|default("", True) }}
 {% if temp in impossible_models %}
-# Skipped {{ classifier }} + {{ feature_extraction }} model{% else %}
-# Classifier = {{ classifier }}, Feature extraction = {{ feature_extraction }} , Query strategy = max
-asreview simulate {{ dataset.input_file }} -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/sim_{{ dataset.input_file_stem }}_{{ classifier }}_{{ feature_extraction }}.asreview --model {{ classifier }} --query_strategy max --feature_extraction {{ feature_extraction }} --init_seed {{ dataset.init_seed }} --seed {{ dataset.model_seed }}
-asreview metrics {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/sim_{{ dataset.input_file_stem }}_{{ classifier }}_{{ feature_extraction }}.asreview -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/metrics_sim_{{ dataset.input_file_stem }}_{{ classifier }}_{{ feature_extraction }}.json{% endif %}
-
 {% endfor %}
 {% endfor %}
 

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -41,6 +41,12 @@ mkdir {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files
 {% for feature_extraction in all_feature_extractors %}
 {% set temp = [] %}{{ temp.append(classifier)|default("", True) }}{{ temp.append(feature_extraction)|default("", True) }}
 {% if temp in impossible_models %}
+# Skipped {{ classifier }} + {{ feature_extraction }} model
+{% else %}# Classifier = {{ classifier }}, Feature extractor = {{ feature_extraction }} , Query strategy = max
+{% for run in range(n_runs) %}
+asreview simulate {{ dataset.input_file }} -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/sim_{{ dataset.input_file_stem }}_{{ classifier }}_{{ feature_extraction }}_{{ run }}.asreview --model {{ classifier }} --query_strategy max --feature_extraction {{ feature_extraction }} --init_seed {{ dataset.init_seed }} --seed {{ dataset.model_seed }}
+asreview metrics {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/sim_{{ dataset.input_file_stem }}_{{ classifier }}_{{ feature_extraction }}_{{ run }}.asreview -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/metrics_sim_{{ dataset.input_file_stem }}_{{ classifier }}_{{ feature_extraction }}_{{ run }}.json
+{% endfor %}{% endif %}
 {% endfor %}
 {% endfor %}
 

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -50,7 +50,7 @@ asreview metrics {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/st
 {% endfor %}
 
 # Generate plot for dataset
-python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png --show_legend
+python {{ scripts_folder }}/get_plot.py -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/ -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/plot_recall_sim_{{ dataset.input_file_stem }}.png --show_legend model
 {% endfor %}
 
 # Merge descriptives and metrics

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -44,7 +44,7 @@ mkdir {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files
 # Skipped {{ classifier }} + {{ feature_extraction }} model
 {% else %}# Classifier = {{ classifier }}, Feature extractor = {{ feature_extraction }} , Query strategy = max
 {% for run in range(n_runs) %}
-asreview simulate {{ dataset.input_file }} -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/sim_{{ dataset.input_file_stem }}_{{ classifier }}_{{ feature_extraction }}_{{ run }}.asreview --model {{ classifier }} --query_strategy max --feature_extraction {{ feature_extraction }} --init_seed {{ dataset.init_seed }} --seed {{ dataset.model_seed }}
+asreview simulate {{ dataset.input_file }} -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/sim_{{ dataset.input_file_stem }}_{{ classifier }}_{{ feature_extraction }}_{{ run }}.asreview --model {{ classifier }} --query_strategy max --feature_extraction {{ feature_extraction }} --init_seed {{ dataset.init_seed + run }} --seed {{ dataset.model_seed }}
 asreview metrics {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/sim_{{ dataset.input_file_stem }}_{{ classifier }}_{{ feature_extraction }}_{{ run }}.asreview -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/metrics_sim_{{ dataset.input_file_stem }}_{{ classifier }}_{{ feature_extraction }}_{{ run }}.json
 {% endfor %}{% endif %}
 {% endfor %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,8 @@ parentdir_prefix = asreview-makita-
 [flake8]
 max-line-length = 88
 ignore =
-    E402,  # module level import not at top of file
+    # module level import not at top of file
+    E402,  
 exclude =
     versioneer.py,
     asreviewcontrib/makita/_version.py


### PR DESCRIPTION
This model changes the following:
- Add multiple runs to multiple models
- Add a legend for every template to get_plot.py
- change the flag feature extraction to feature extractor
- Update readme
- Multiple runs increases the init seed for every run
- Small change to settings file for flake8 test
- enable filename based legend for ARFI @Rensvandeschoot 
- Add model setting with 4 models

This branch is branched from #4 for continuity.