### PR TITLE
Fix bug with seed values in basic template and some minor other improvements

### DIFF
--- a/asreviewcontrib/makita/entrypoint.py
+++ b/asreviewcontrib/makita/entrypoint.py
@@ -25,8 +25,8 @@ def is_valid_template(fp):
 
 def _valid_job_file(param):
     ext = Path(param).suffix
-    if ext.lower() not in ('.sh', '.bat'):
-        raise argparse.ArgumentTypeError('File must have a .sh or .bat extension')
+    if ext.lower() not in ('.sh', '.bat', '.yaml'):
+        raise argparse.ArgumentTypeError('File must have a .sh, .bat, .yaml extension')
     return param
 
 

--- a/asreviewcontrib/makita/template_arfi.py
+++ b/asreviewcontrib/makita/template_arfi.py
@@ -70,22 +70,25 @@ def render_jobs_arfi(
     # open template TODO@{Replace by more sustainable module}
     template = ConfigTemplate(fp_template)
 
-    for s in template.scripts:
-        t_script = get_file(s, "script")
-        export_fp = Path(scripts_folder, s)
-        add_file(t_script, export_fp)
+    # check if template.script is not NoneType
+    if template.scripts is not None:
+        for s in template.scripts:
+            t_script = get_file(s, "script")
+            export_fp = Path(scripts_folder, s)
+            add_file(t_script, export_fp)
 
-    for s in template.docs:
-        t_docs = get_file(s,
-                          "doc",
-                          datasets=datasets,
-                          template_name=template.name if template.name == "ARFI" else "custom", # NOQA
-                          template_name_long=template.name_long,
-                          template_scripts=template.scripts,
-                          output_folder=output_folder,
-                          job_file=job_file,
-                          )
-        add_file(t_docs, s)
+    if template.docs is not None:
+        for s in template.docs:
+            t_docs = get_file(s,
+                            "doc",
+                            datasets=datasets,
+                            template_name=template.name if template.name == "ARFI" else "custom", # NOQA
+                            template_name_long=template.name_long,
+                            template_scripts=template.scripts,
+                            output_folder=output_folder,
+                            job_file=job_file,
+                            )
+            add_file(t_docs, s)
 
     return template.render(
         {

--- a/asreviewcontrib/makita/template_arfi.py
+++ b/asreviewcontrib/makita/template_arfi.py
@@ -55,7 +55,10 @@ def render_jobs_arfi(
         check_filename_dataset(fp_dataset)
 
         # render priors
-        priors = get_priors(fp_dataset, init_seed=init_seed + i, n_priors=n_priors)
+        priors = get_priors(fp_dataset,
+                            init_seed=init_seed + i,
+                            n_priors=n_priors
+                            )
 
         # params for single dataset
         params.append(
@@ -80,14 +83,14 @@ def render_jobs_arfi(
     if template.docs is not None:
         for s in template.docs:
             t_docs = get_file(s,
-                            "doc",
-                            datasets=datasets,
-                            template_name=template.name if template.name == "ARFI" else "custom", # NOQA
-                            template_name_long=template.name_long,
-                            template_scripts=template.scripts,
-                            output_folder=output_folder,
-                            job_file=job_file,
-                            )
+                              "doc",
+                              datasets=datasets,
+                              template_name=template.name if template.name == "ARFI" else "custom",  # NOQA
+                              template_name_long=template.name_long,
+                              template_scripts=template.scripts,
+                              output_folder=output_folder,
+                              job_file=job_file,
+                              )
             add_file(t_docs, s)
 
     return template.render(

--- a/asreviewcontrib/makita/templates/template_basic.txt.template
+++ b/asreviewcontrib/makita/templates/template_basic.txt.template
@@ -42,7 +42,7 @@ asreview wordcloud {{ dataset.input_file }} -o {{ output_folder }}/simulation/{{
 # Simulate runs
 mkdir {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files
 {% for run in range(dataset.n_runs) %}
-asreview simulate {{ dataset.input_file }} -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/sim_{{ dataset.input_file_stem }}_{{ run }}.asreview --init_seed {{ dataset.init_seed }} --seed {{ dataset.model_seed }}
+asreview simulate {{ dataset.input_file }} -s {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/sim_{{ dataset.input_file_stem }}_{{ run }}.asreview --init_seed {{ dataset.init_seed + run}} --seed {{ dataset.model_seed + run}}
 asreview metrics {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/state_files/sim_{{ dataset.input_file_stem }}_{{ run }}.asreview -o {{ output_folder }}/simulation/{{ dataset.input_file_stem }}/metrics/metrics_sim_{{ dataset.input_file_stem }}_{{ run }}.json
 {% endfor %}
 


### PR DESCRIPTION
This PR solves some smaller issues. 
- It should be possible to use a template that has no scripts or docs generated
- Added .yaml as valid extension for the jobs file (we should consider removing the restriction all together)
- `n_runs` should iterate over seeds for all templates.
- Linter issues