### PR TITLE
Choose priors without replacements in template_arfi.py

### DIFF
--- a/asreviewcontrib/makita/template_arfi.py
+++ b/asreviewcontrib/makita/template_arfi.py
@@ -26,7 +26,8 @@ def get_priors(dataset, init_seed, n_priors):
     np.random.seed(init_seed)
 
     # sample n_priors irrelevant records
-    prior_irrelevant = list(np.random.choice(relevant_irrecord_ids, n_priors, replace=False))
+    prior_irrelevant = list(np.random.choice(relevant_irrecord_ids, n_priors,
+                                             replace=False))
 
     priors = []
 


### PR DESCRIPTION
Closes #25 

I have not tested it.

`np.random.choice`: https://numpy.org/doc/stable/reference/random/generated/numpy.random.choice.html