### PR TITLE
Add filehandler and implement overwrite protection

### DIFF
--- a/asreviewcontrib/makita/entrypoint.py
+++ b/asreviewcontrib/makita/entrypoint.py
@@ -7,8 +7,7 @@ from asreviewcontrib.makita.config import TEMPLATES_FP
 from asreviewcontrib.makita.template_arfi import render_jobs_arfi
 from asreviewcontrib.makita.template_basic import render_jobs_basic
 from asreviewcontrib.makita.template_multiple_models import render_jobs_multiple_models
-from asreviewcontrib.makita.utils import add_file
-from asreviewcontrib.makita.utils import get_file
+from asreviewcontrib.makita.utils import FileHandler
 
 
 def get_template_fp(name):
@@ -47,6 +46,9 @@ class MakitaEntryPoint(BaseEntryPoint):
         super(MakitaEntryPoint, self).__init__()
 
         self.version = __version__
+
+        # initialize file handler
+        self.file_handler = FileHandler()
 
     def execute(self, argv):  # noqa: C901
 
@@ -187,10 +189,11 @@ class MakitaEntryPoint(BaseEntryPoint):
         parser = _parse_arguments_scripts(self.version)
         args = parser.parse_args(args_name)
         params = {}
-        new_script = get_file(args_program.name, "script", **params)
+        new_script = self.file_handler.get_file(args_program.name, "script", **params)
 
         export_fp = Path(args.o, args_program.name)
-        add_file(new_script, export_fp)
+        self.file_handler.add_file(new_script, export_fp)
+        self.file_handler.print_summary()
 
 
 def _parse_arguments_program(version="Unknown", add_help=False):

--- a/asreviewcontrib/makita/template_arfi.py
+++ b/asreviewcontrib/makita/template_arfi.py
@@ -7,9 +7,7 @@ from asreview import ASReviewData
 from cfgtemplater.config_template import ConfigTemplate
 
 from asreviewcontrib.makita import __version__
-from asreviewcontrib.makita.utils import add_file
-from asreviewcontrib.makita.utils import check_filename_dataset
-from asreviewcontrib.makita.utils import get_file
+from asreviewcontrib.makita.utils import FileHandler
 
 
 def get_priors(dataset, init_seed, n_priors):
@@ -51,9 +49,12 @@ def render_jobs_arfi(
     """Render jobs."""
     params = []
 
+    # initialize file handler
+    file_handler = FileHandler()
+
     for i, fp_dataset in enumerate(sorted(datasets)):
 
-        check_filename_dataset(fp_dataset)
+        file_handler.check_filename_dataset(fp_dataset)
 
         # render priors
         priors = get_priors(fp_dataset,
@@ -77,13 +78,13 @@ def render_jobs_arfi(
     # check if template.script is not NoneType
     if template.scripts is not None:
         for s in template.scripts:
-            t_script = get_file(s, "script")
+            t_script = file_handler.get_file(s, "script")
             export_fp = Path(scripts_folder, s)
-            add_file(t_script, export_fp)
+            file_handler.add_file(t_script, export_fp)
 
     if template.docs is not None:
         for s in template.docs:
-            t_docs = get_file(s,
+            t_docs = file_handler.get_file(s,
                               "doc",
                               datasets=datasets,
                               template_name=template.name if template.name == "ARFI" else "custom",  # NOQA
@@ -92,7 +93,9 @@ def render_jobs_arfi(
                               output_folder=output_folder,
                               job_file=job_file,
                               )
-            add_file(t_docs, s)
+            file_handler.add_file(t_docs, s)
+
+    file_handler.print_summary()
 
     return template.render(
         {

--- a/asreviewcontrib/makita/template_basic.py
+++ b/asreviewcontrib/makita/template_basic.py
@@ -5,9 +5,7 @@ from pathlib import Path
 from cfgtemplater.config_template import ConfigTemplate
 
 from asreviewcontrib.makita import __version__
-from asreviewcontrib.makita.utils import add_file
-from asreviewcontrib.makita.utils import check_filename_dataset
-from asreviewcontrib.makita.utils import get_file
+from asreviewcontrib.makita.utils import FileHandler
 
 
 def render_jobs_basic(
@@ -23,9 +21,12 @@ def render_jobs_basic(
     """Render jobs."""
     params = []
 
+    # initialize file handler
+    file_handler = FileHandler()
+
     for i, fp_dataset in enumerate(sorted(datasets)):
 
-        check_filename_dataset(fp_dataset)
+        file_handler.check_filename_dataset(fp_dataset)
 
         fp_dataset = Path(fp_dataset)
 
@@ -44,21 +45,23 @@ def render_jobs_basic(
     template = ConfigTemplate(fp_template)
 
     for s in template.scripts:
-        t_script = get_file(s, "script")
+        t_script = file_handler.get_file(s, "script")
         export_fp = Path(scripts_folder, s)
-        add_file(t_script, export_fp)
+        file_handler.add_file(t_script, export_fp)
 
     for s in template.docs:
-        t_docs = get_file(s,
-                          "doc",
-                          datasets=datasets,
-                          template_name=template.name if template.name == "basic" else "custom", # NOQA
-                          template_name_long=template.name_long,
-                          template_scripts=template.scripts,
-                          output_folder=output_folder,
-                          job_file=job_file,
-                          )
-        add_file(t_docs, s)
+        t_docs = file_handler.get_file(s,
+                                       "doc",
+                                       datasets=datasets,
+                                       template_name=template.name if template.name == "basic" else "custom",  # NOQA
+                                       template_name_long=template.name_long,
+                                       template_scripts=template.scripts,
+                                       output_folder=output_folder,
+                                       job_file=job_file,
+                                       )
+        file_handler.add_file(t_docs, s)
+
+    file_handler.print_summary()
 
     return template.render(
         {

--- a/asreviewcontrib/makita/template_multiple_models.py
+++ b/asreviewcontrib/makita/template_multiple_models.py
@@ -5,9 +5,7 @@ from pathlib import Path
 from cfgtemplater.config_template import ConfigTemplate
 
 from asreviewcontrib.makita import __version__
-from asreviewcontrib.makita.utils import add_file
-from asreviewcontrib.makita.utils import check_filename_dataset
-from asreviewcontrib.makita.utils import get_file
+from asreviewcontrib.makita.utils import FileHandler
 
 
 def render_jobs_multiple_models(
@@ -26,9 +24,12 @@ def render_jobs_multiple_models(
     """Render jobs."""
     params = []
 
+    # initialize file handler
+    file_handler = FileHandler()
+
     for i, fp_dataset in enumerate(sorted(datasets)):
 
-        check_filename_dataset(fp_dataset)
+        file_handler.check_filename_dataset(fp_dataset)
 
         fp_dataset = Path(fp_dataset)
 
@@ -46,12 +47,12 @@ def render_jobs_multiple_models(
     template = ConfigTemplate(fp_template)
 
     for s in template.scripts:
-        t_script = get_file(s, "script")
+        t_script = file_handler.get_file(s, "script")
         export_fp = Path(scripts_folder, s)
-        add_file(t_script, export_fp)
+        file_handler.add_file(t_script, export_fp)
 
     for s in template.docs:
-        t_docs = get_file(s,
+        t_docs = file_handler.get_file(s,
                           "doc",
                           datasets=datasets,
                           template_name=template.name if template.name == "multiple_models" else "custom", # NOQA
@@ -60,7 +61,9 @@ def render_jobs_multiple_models(
                           output_folder=output_folder,
                           job_file=job_file,
                           )
-        add_file(t_docs, s)
+        file_handler.add_file(t_docs, s)
+    
+    file_handler.print_summary()
 
     return template.render(
         {

--- a/asreviewcontrib/makita/utils.py
+++ b/asreviewcontrib/makita/utils.py
@@ -6,32 +6,55 @@ from asreviewcontrib.makita import __version__
 from asreviewcontrib.makita.config import TEMPLATES_FP
 
 
-def get_file(name, file_type, **kwargs):
+class FileHandler:
+    def __init__(self):
+        self.overwrite_all = False
+        self.total_files = 0
 
-    params = {
-        "version": __version__,
-    }
+    def add_file(self, content, export_fp):
+        # Check if the file already exists
+        if Path(export_fp).exists() and not self.overwrite_all:
+            response = None
+            while response not in ["y", "n", "a"]:
+                response = input(f"Overwrite {export_fp} (Yes/No/All)? ").lower()
+                if response == "y":
+                    # Overwrite the file
+                    break
+                elif response == "n":
+                    # Do not overwrite, return from function
+                    print(f"Skipped {export_fp}")
+                    return
+                elif response == "a":
+                    # Overwrite all files
+                    self.overwrite_all = True
+                    break
 
-    print(f"Loading {file_type} {name}")
+        # store result in output folder
+        Path(export_fp).parent.mkdir(parents=True, exist_ok=True)
 
-    # open template
-    with open(Path(TEMPLATES_FP, f"{file_type}_{name}.template")) as f:
-        template = Template(f.read())
+        with open(export_fp, "w") as f:
+            f.write(content)
+        
+        print(f"Added {export_fp}")
+        self.total_files += 1
 
-    return template.render({**params, **kwargs})
+    def print_summary(self):
+        print(f"{self.total_files} file(s) created.")
 
+    def check_filename_dataset(self, fp):
+        if (' ' in Path(fp).stem):
+            raise ValueError(f"Dataset filename '{fp}' cannot contain whitespace.")
 
-def add_file(content, export_fp):
+    def get_file(self, name, file_type, **kwargs):
 
-    # store result in output folder
-    Path(export_fp).parent.mkdir(parents=True, exist_ok=True)
+        params = {
+            "version": __version__,
+        }
 
-    with open(export_fp, "w") as f:
-        f.write(content)
+        print(f"Loading {file_type} {name}")
 
-    print(f"Added {export_fp}")
+        # open template
+        with open(Path(TEMPLATES_FP, f"{file_type}_{name}.template")) as f:
+            template = Template(f.read())
 
-
-def check_filename_dataset(fp):
-    if (' ' in Path(fp).stem):
-        raise ValueError(f"Dataset filename '{fp}' cannot contain whitespace.")
+        return template.render({**params, **kwargs})


### PR DESCRIPTION
Following issue #15, this PR replaces the file handling with a separate file handler. 

Example interaction:
```console
>asreview makita template arfi -f jobs.bat
Loading script get_plot.py
Overwrite scripts\get_plot.py (Yes/No/All)?
Overwrite scripts\get_plot.py (Yes/No/All)? n
Skipped scripts\get_plot.py
Loading script merge_descriptives.py
Overwrite scripts\merge_descriptives.py (Yes/No/All)? y
Added scripts\merge_descriptives.py
Loading script merge_metrics.py
Overwrite scripts\merge_metrics.py (Yes/No/All)? y
Added scripts\merge_metrics.py
Loading script merge_tds.py
Overwrite scripts\merge_tds.py (Yes/No/All)? y
Added scripts\merge_tds.py
Loading doc README.md
Overwrite README.md (Yes/No/All)? y
Added README.md
4 file(s) created.
Rendered template arfi and saved to jobs.bat
```