### PR TITLE
Fix various smaller issues

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -13,6 +13,9 @@ jobs:
     - name: Install makita
       run: |
         pip install .
+    - name: Install flake8
+      run: |
+        pip install flake8
     - name: set up environment
       run: |
         mkdir tmp
@@ -40,16 +43,13 @@ jobs:
         scandir: './tmp'
       env:
         SHELLCHECK_OPTS: -e SC2148
-    - name: Test makita scripts
+    - name: Generate makita scripts
       run: |  
         asreview makita add-script get_plot.py
         asreview makita add-script merge_descriptives.py
         asreview makita add-script merge_metrics.py
         asreview makita add-script merge_tds.py
         asreview makita add-script get_settings_from_state.py
-    - name: Install flake8
-      run: |
-        pip install flake8
     - name: Lint python with flake8
       run: |
         flake8 . --max-complexity=10 --statistics

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,28 +1,7 @@
 name: test-suite
 on: [push, pull_request]
 jobs:
-  lint-python:
-    name: lint-python
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.8'
-        architecture: 'x64'
-    - name: Install flake8
-      run: |
-        pip install flake8
-    - name: Add templates to flake8 check
-      run: |
-        for file in asreviewcontrib/makita/templates/*.template; do 
-          mv "$file" "${file%.template}"
-          echo "Modified file: ${file%.template}"
-        done
-    - name: Lint python with flake8
-      run: |
-        flake8 . --max-complexity=10 --statistics --ignore=W391
-  test-template:
+  test-template-and-lint:
     name: test-templates-and-scripts
     runs-on: ubuntu-latest
     steps:
@@ -68,3 +47,9 @@ jobs:
         asreview makita add-script merge_metrics.py
         asreview makita add-script merge_tds.py
         asreview makita add-script get_settings_from_state.py
+    - name: Install flake8
+      run: |
+        pip install flake8
+    - name: Lint python with flake8
+      run: |
+        flake8 . --max-complexity=10 --statistics

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -45,11 +45,7 @@ jobs:
         SHELLCHECK_OPTS: -e SC2148
     - name: Generate makita scripts
       run: |  
-        asreview makita add-script get_plot.py
-        asreview makita add-script merge_descriptives.py
-        asreview makita add-script merge_metrics.py
-        asreview makita add-script merge_tds.py
-        asreview makita add-script get_settings_from_state.py
+        asreview makita add-script --all
     - name: Lint python with flake8
       run: |
         flake8 . --max-complexity=10 --statistics

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -21,9 +21,9 @@ jobs:
         done
     - name: Lint python with flake8
       run: |
-        flake8 . --max-complexity=10 --statistics
+        flake8 . --max-complexity=10 --statistics --ignore=W391
   test-template:
-    name: test-templates-scripts
+    name: test-templates-and-scripts
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -26,7 +26,7 @@ from asreview import open_state
 from asreviewcontrib.insights.plot import plot_recall
 
 
-def get_plot_from_states(state_path, filename, legend=None):
+def get_plot_from_states(states, filename, legend=None):
     """Generate an ASReview plot from state files."""
 
     fig, ax = plt.subplots()
@@ -34,7 +34,7 @@ def get_plot_from_states(state_path, filename, legend=None):
     labels = []
     colors = list(mcolors.TABLEAU_COLORS.values())
 
-    for state_file in Path(state_path).glob("*.asreview"):
+    for state_file in states:
         with open_state(state_file) as state:
             # draw the plot
             plot_recall(ax, state)
@@ -87,10 +87,13 @@ if __name__ == "__main__":
         help="Add a legend to the plot, based on the given parameter.")
     args = parser.parse_args()
 
+    # load states
+    states = Path(args.s).glob("*.asreview")
+
     # check if states are found
     if len(list(states)) == 0:
         raise FileNotFoundError(f"No state files found in {args.s}")
 
     # generate plot and save results
-    get_plot_from_states(args.s, args.o, args.show_legend)
+    get_plot_from_states(states, args.o, args.show_legend)
 

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -89,3 +89,4 @@ if __name__ == "__main__":
 
     # generate plot and save results
     get_plot_from_states(args.s, args.o, args.show_legend)
+

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -87,6 +87,10 @@ if __name__ == "__main__":
         help="Add a legend to the plot, based on the given parameter.")
     args = parser.parse_args()
 
+    # check if states are found
+    if len(list(states)) == 0:
+        raise FileNotFoundError(f"No state files found in {args.s}")
+
     # generate plot and save results
     get_plot_from_states(args.s, args.o, args.show_legend)
 

--- a/asreviewcontrib/makita/templates/script_get_settings_from_state.py.template
+++ b/asreviewcontrib/makita/templates/script_get_settings_from_state.py.template
@@ -60,3 +60,4 @@ if __name__ == '__main__':
 
     with open(Path(args.o), "w") as f:
         json.dump(result, f)
+

--- a/asreviewcontrib/makita/templates/script_merge_descriptives.py.template
+++ b/asreviewcontrib/makita/templates/script_merge_descriptives.py.template
@@ -73,3 +73,4 @@ if __name__ == "__main__":
     Path(args.o).parent.mkdir(parents=True, exist_ok=True)
     result.to_csv(Path(args.o))
     result.to_excel(Path(args.o).with_suffix('.xlsx'))
+

--- a/asreviewcontrib/makita/templates/script_merge_descriptives.py.template
+++ b/asreviewcontrib/makita/templates/script_merge_descriptives.py.template
@@ -53,8 +53,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-s",
         type=str,
-        nargs="*",
-        default="output/simulation/*/descriptives/data_stats_*.json",
+        default="output/simulation/*/descriptives/",
         help="Datasets location")
     parser.add_argument(
         "-o",
@@ -64,7 +63,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # load datasets
-    datasets = glob.glob(args.s)
+    datasets = glob.glob(args.s + "data_stats_*.json")
 
     # merge results
     result = create_table_descriptives(datasets)

--- a/asreviewcontrib/makita/templates/script_merge_descriptives.py.template
+++ b/asreviewcontrib/makita/templates/script_merge_descriptives.py.template
@@ -65,6 +65,10 @@ if __name__ == "__main__":
     # load datasets
     datasets = glob.glob(args.s + "data_stats_*.json")
 
+    # check if states are found
+    if len(datasets) == 0:
+        raise FileNotFoundError("No datasets found in " + args.s)
+
     # merge results
     result = create_table_descriptives(datasets)
 

--- a/asreviewcontrib/makita/templates/script_merge_metrics.py.template
+++ b/asreviewcontrib/makita/templates/script_merge_metrics.py.template
@@ -76,3 +76,4 @@ if __name__ == "__main__":
     Path(args.o).parent.mkdir(parents=True, exist_ok=True)
     result.to_csv(Path(args.o))
     result.to_excel(Path(args.o).with_suffix('.xlsx'))
+

--- a/asreviewcontrib/makita/templates/script_merge_metrics.py.template
+++ b/asreviewcontrib/makita/templates/script_merge_metrics.py.template
@@ -27,14 +27,14 @@ from pathlib import Path
 import pandas as pd
 
 
-def create_table_state_metrics(states):
+def create_table_state_metrics(metrics):
     metrics = []
 
-    for state in states:
-        with open(state) as f:
+    for metric in metrics:
+        with open(metric) as f:
             data = json.load(f)['data']['items']
             values = {}
-            values['file_name'] = Path(state).name
+            values['file_name'] = Path(metric).name
             for item in data:
                 if item['id'] == 'td':
                     continue
@@ -66,14 +66,15 @@ if __name__ == "__main__":
         help="Output table location")
     args = parser.parse_args()
 
-    # load states
-    states = glob.glob(args.s + "metrics_sim_*.json")
+    # load metrics
+    metrics = glob.glob(args.s + "metrics_sim_*.json")
+
     # check if states are found
     if len(metrics) == 0:
         raise FileNotFoundError("No metrics found in " + args.s)
 
     # merge results
-    result = create_table_state_metrics(states)
+    result = create_table_state_metrics(metrics)
 
     # store result in output folder
     Path(args.o).parent.mkdir(parents=True, exist_ok=True)

--- a/asreviewcontrib/makita/templates/script_merge_metrics.py.template
+++ b/asreviewcontrib/makita/templates/script_merge_metrics.py.template
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # load states
-    states = glob.glob(args.s + "*")
+    states = glob.glob(args.s + "metrics_sim_*.json")
 
     # merge results
     result = create_table_state_metrics(states)

--- a/asreviewcontrib/makita/templates/script_merge_metrics.py.template
+++ b/asreviewcontrib/makita/templates/script_merge_metrics.py.template
@@ -27,10 +27,10 @@ from pathlib import Path
 import pandas as pd
 
 
-def create_table_state_metrics(metrics):
+def create_table_state_metrics(metric_files):
     metrics = []
 
-    for metric in metrics:
+    for metric in metric_files:
         with open(metric) as f:
             data = json.load(f)['data']['items']
             values = {}
@@ -66,15 +66,15 @@ if __name__ == "__main__":
         help="Output table location")
     args = parser.parse_args()
 
-    # load metrics
-    metrics = glob.glob(args.s + "metrics_sim_*.json")
+    # load metric files
+    metric_files = glob.glob(args.s + "metrics_sim_*.json")
 
     # check if states are found
-    if len(metrics) == 0:
+    if len(metric_files) == 0:
         raise FileNotFoundError("No metrics found in " + args.s)
 
     # merge results
-    result = create_table_state_metrics(metrics)
+    result = create_table_state_metrics(metric_files)
 
     # store result in output folder
     Path(args.o).parent.mkdir(parents=True, exist_ok=True)

--- a/asreviewcontrib/makita/templates/script_merge_metrics.py.template
+++ b/asreviewcontrib/makita/templates/script_merge_metrics.py.template
@@ -68,6 +68,9 @@ if __name__ == "__main__":
 
     # load states
     states = glob.glob(args.s + "metrics_sim_*.json")
+    # check if states are found
+    if len(metrics) == 0:
+        raise FileNotFoundError("No metrics found in " + args.s)
 
     # merge results
     result = create_table_state_metrics(states)

--- a/asreviewcontrib/makita/templates/script_merge_tds.py.template
+++ b/asreviewcontrib/makita/templates/script_merge_tds.py.template
@@ -68,3 +68,4 @@ if __name__ == "__main__":
     Path(args.o).parent.mkdir(parents=True, exist_ok=True)
     result.to_csv(Path(args.o))
     result.to_excel(Path(args.o).with_suffix('.xlsx'))
+

--- a/asreviewcontrib/makita/templates/script_split_data_with_multiple_labels.py.template
+++ b/asreviewcontrib/makita/templates/script_split_data_with_multiple_labels.py.template
@@ -101,3 +101,4 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     etl(args.s, args.o, split=args.split, suffix=args.suffix)
+

--- a/asreviewcontrib/makita/templates/template_arfi.txt.template
+++ b/asreviewcontrib/makita/templates/template_arfi.txt.template
@@ -52,6 +52,6 @@ python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/{
 {% endfor %}
 
 # Merge descriptives and metrics
-python {{ scripts_folder }}/merge_descriptives.py -s {{ output_folder }}/simulation/*/descriptives/data_stats_*.json -o {{ output_folder }}/tables/data_descriptives_all.csv
+python {{ scripts_folder }}/merge_descriptives.py -s {{ output_folder }}/simulation/*/descriptives/ -o {{ output_folder }}/tables/data_descriptives_all.csv
 python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/*/metrics/ -o {{ output_folder }}/tables/metrics_sim_all.csv
 

--- a/asreviewcontrib/makita/templates/template_arfi.txt.template
+++ b/asreviewcontrib/makita/templates/template_arfi.txt.template
@@ -52,6 +52,6 @@ python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/{
 {% endfor %}
 
 # Merge descriptives and metrics
-python {{ scripts_folder }}/merge_descriptives.py
+python {{ scripts_folder }}/merge_descriptives.py -s {{ output_folder }}/simulation/*/descriptives/data_stats_*.json -o {{ output_folder }}/tables/data_descriptives_all.csv
 python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/*/metrics/ -o {{ output_folder }}/tables/metrics_sim_all.csv
 

--- a/asreviewcontrib/makita/templates/template_arfi.txt.template
+++ b/asreviewcontrib/makita/templates/template_arfi.txt.template
@@ -53,5 +53,5 @@ python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/{
 
 # Merge descriptives and metrics
 python {{ scripts_folder }}/merge_descriptives.py
-python {{ scripts_folder }}/merge_metrics.py
+python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/*/metrics/ -o {{ output_folder }}/tables/metrics_sim_all.csv
 

--- a/asreviewcontrib/makita/templates/template_basic.txt.template
+++ b/asreviewcontrib/makita/templates/template_basic.txt.template
@@ -54,6 +54,6 @@ python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/{
 {% endfor %}
 
 # Merge descriptives and metrics
-python {{ scripts_folder }}/merge_descriptives.py
+python {{ scripts_folder }}/merge_descriptives.py -s {{ output_folder }}/simulation/*/descriptives/data_stats_*.json -o {{ output_folder }}/tables/data_descriptives_all.csv
 python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/*/metrics/ -o {{ output_folder }}/tables/metrics_sim_all.csv
 

--- a/asreviewcontrib/makita/templates/template_basic.txt.template
+++ b/asreviewcontrib/makita/templates/template_basic.txt.template
@@ -55,5 +55,5 @@ python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/{
 
 # Merge descriptives and metrics
 python {{ scripts_folder }}/merge_descriptives.py
-python {{ scripts_folder }}/merge_metrics.py 
+python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/*/metrics/ -o {{ output_folder }}/tables/metrics_sim_all.csv
 

--- a/asreviewcontrib/makita/templates/template_basic.txt.template
+++ b/asreviewcontrib/makita/templates/template_basic.txt.template
@@ -54,6 +54,6 @@ python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/{
 {% endfor %}
 
 # Merge descriptives and metrics
-python {{ scripts_folder }}/merge_descriptives.py -s {{ output_folder }}/simulation/*/descriptives/data_stats_*.json -o {{ output_folder }}/tables/data_descriptives_all.csv
+python {{ scripts_folder }}/merge_descriptives.py -s {{ output_folder }}/simulation/*/descriptives/ -o {{ output_folder }}/tables/data_descriptives_all.csv
 python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/*/metrics/ -o {{ output_folder }}/tables/metrics_sim_all.csv
 

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -60,6 +60,6 @@ python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/{
 {% endfor %}
 
 # Merge descriptives and metrics
-python {{ scripts_folder }}/merge_descriptives.py
+python {{ scripts_folder }}/merge_descriptives.py -s {{ output_folder }}/simulation/*/descriptives/data_stats_*.json -o {{ output_folder }}/tables/data_descriptives_all.csv
 python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/*/metrics/ -o {{ output_folder }}/tables/metrics_sim_all.csv
 

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -60,6 +60,6 @@ python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/{
 {% endfor %}
 
 # Merge descriptives and metrics
-python {{ scripts_folder }}/merge_descriptives.py -s {{ output_folder }}/simulation/*/descriptives/data_stats_*.json -o {{ output_folder }}/tables/data_descriptives_all.csv
+python {{ scripts_folder }}/merge_descriptives.py -s {{ output_folder }}/simulation/*/descriptives/ -o {{ output_folder }}/tables/data_descriptives_all.csv
 python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/*/metrics/ -o {{ output_folder }}/tables/metrics_sim_all.csv
 

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -61,5 +61,5 @@ python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/{
 
 # Merge descriptives and metrics
 python {{ scripts_folder }}/merge_descriptives.py
-python {{ scripts_folder }}/merge_metrics.py
+python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/*/metrics/ -o {{ output_folder }}/tables/metrics_sim_all.csv
 


### PR DESCRIPTION
This PR excludes W391 from flake as double blank lines at the end of the scripts are needed in the templates for them to be rendered correctly.

This PR also solves issues with a custom output folder. Although we should have a discussion about why we allow any other output folder than output.

See:
![image](https://github.com/asreview/asreview-makita/assets/28191416/8c59104c-2036-44a8-94ac-e540b7da0cbb)

If we consider the jobs file and the data set to be integral to the generated folder we should prefer a separate parent folder for each simulation, not just a separate output folder
