### PR TITLE
Print generated scripts only once, and other small updates

### DIFF
--- a/asreviewcontrib/makita/entrypoint.py
+++ b/asreviewcontrib/makita/entrypoint.py
@@ -51,14 +51,19 @@ class MakitaEntryPoint(BaseEntryPoint):
         parser = _parse_arguments_program(self.version)
         args_program, args_name = parser.parse_known_args(argv)
 
-        # generate templates
+        # Main entry point of the program, routing to either the 'template' 
+        # or 'add-script' functions based on user input.
+
+        # route to template
         if args_program.tool == "template":
             try:
                 self._template(args_name, args_program)
             except Exception as err:
                 print(f"\u001b[31mERROR: {err}\u001b[0m")
+        # route to add-script
         elif args_program.tool == "add-script":
             self._add_script(args_name, args_program)
+        # error if tool is not recognized
         else:
             parser.error(
                 f"Error: Can't find '{args_program.tool}' "
@@ -66,6 +71,8 @@ class MakitaEntryPoint(BaseEntryPoint):
             )
 
     def _template(self, args_name, args_program):
+        '''Generate a template.'''
+
         # generate basic arguments
         parser = _parse_arguments_template(self.version)
 

--- a/asreviewcontrib/makita/entrypoint.py
+++ b/asreviewcontrib/makita/entrypoint.py
@@ -201,7 +201,7 @@ class MakitaEntryPoint(BaseEntryPoint):
             # export script
             export_fp = Path(args.o, script)
             self.file_handler.add_file(new_script, export_fp)
-            self.file_handler.print_summary()
+        self.file_handler.print_summary()
 
 
 def _parse_arguments_program(version="Unknown", add_help=False):

--- a/asreviewcontrib/makita/entrypoint.py
+++ b/asreviewcontrib/makita/entrypoint.py
@@ -181,7 +181,7 @@ class MakitaEntryPoint(BaseEntryPoint):
         self.file_handler = FileHandler()
 
         # parse arguments
-        parser = _parse_arguments_scripts(self.version)
+        parser = _parse_arguments_scripts()
         args = parser.parse_args(args_name)
 
         tmp_scripts = []
@@ -253,7 +253,7 @@ def _parse_arguments_template(version):
     return parser
 
 
-def _parse_arguments_scripts(version):
+def _parse_arguments_scripts():
     parser = argparse.ArgumentParser(prog="asreview makita", add_help=True)
     parser.add_argument("--all", "-a", action="store_true", help="Add all scripts.")
     parser.add_argument(

--- a/asreviewcontrib/makita/entrypoint.py
+++ b/asreviewcontrib/makita/entrypoint.py
@@ -73,8 +73,8 @@ class MakitaEntryPoint(BaseEntryPoint):
     def _template(self, args_name, args_program):
         '''Generate a template.'''
 
-        # generate basic arguments
-        parser = _parse_arguments_template(self.version)
+        # generate arguments used for all templates
+        parser = _parse_arguments_template()
 
         # template specific arguments
         if args_program.name in ["basic", "multiple_models"]:

--- a/asreviewcontrib/makita/entrypoint.py
+++ b/asreviewcontrib/makita/entrypoint.py
@@ -231,7 +231,7 @@ def _parse_arguments_program(version="Unknown", add_help=False):
     return parser
 
 
-def _parse_arguments_template(version):
+def _parse_arguments_template():
     parser = argparse.ArgumentParser(prog="asreview makita", add_help=True)
 
     parser.add_argument(

--- a/asreviewcontrib/makita/template_arfi.py
+++ b/asreviewcontrib/makita/template_arfi.py
@@ -27,6 +27,7 @@ def render_jobs_arfi(
     # initialize file handler
     file_handler = FileHandler()
 
+    # generate params for all simulations
     for i, fp_dataset in enumerate(sorted(datasets)):
         check_filename_dataset(fp_dataset)
 
@@ -43,7 +44,8 @@ def render_jobs_arfi(
             }
         )
 
-    # open template TODO@{Replace by more sustainable module}
+    # Instantiate a ConfigTemplate object, initializing a Jinja2 environment and 
+    # setting up template variables and extensions.
     template = ConfigTemplate(fp_template)
 
     # render scripts
@@ -73,6 +75,7 @@ def render_jobs_arfi(
             )
             file_handler.add_file(t_docs, s)
 
+    # print summary to console
     file_handler.print_summary()
 
     return template.render(

--- a/asreviewcontrib/makita/template_arfi.py
+++ b/asreviewcontrib/makita/template_arfi.py
@@ -49,14 +49,15 @@ def render_jobs_arfi(
     template = ConfigTemplate(fp_template)
 
     # render scripts
-    for s in template.scripts:
-        t_script = file_handler.render_file_from_template(
-            s, 
-            "script", 
-            output_folder=output_folder
-        )
-        export_fp = Path(scripts_folder, s)
-        file_handler.add_file(t_script, export_fp)
+    if template.scripts is not None:
+        for s in template.scripts:
+            t_script = file_handler.render_file_from_template(
+                s, 
+                "script", 
+                output_folder=output_folder
+            )
+            export_fp = Path(scripts_folder, s)
+            file_handler.add_file(t_script, export_fp)
 
     # render docs
     if template.docs is not None:

--- a/asreviewcontrib/makita/template_arfi.py
+++ b/asreviewcontrib/makita/template_arfi.py
@@ -78,6 +78,7 @@ def render_jobs_arfi(
     # print summary to console
     file_handler.print_summary()
 
+    # render file and return
     return template.render(
         {
             "datasets": params,

--- a/asreviewcontrib/makita/template_arfi.py
+++ b/asreviewcontrib/makita/template_arfi.py
@@ -67,9 +67,9 @@ def render_jobs_arfi(
                 datasets=datasets,
                 template_name=template.name
                 if template.name == "ARFI"
-                else "custom",  # NOQA
-                template_name_long=template.name_long,  # NOQA
-                template_scripts=template.scripts,  # NOQA
+                else "custom",
+                template_name_long=template.name_long,
+                template_scripts=template.scripts,
                 output_folder=output_folder,
                 job_file=job_file,
             )

--- a/asreviewcontrib/makita/template_arfi.py
+++ b/asreviewcontrib/makita/template_arfi.py
@@ -76,7 +76,11 @@ def render_jobs_arfi(
     # check if template.script is not NoneType
     if template.scripts is not None:
         for s in template.scripts:
-            t_script = file_handler.render_file_from_template(s, "script")
+            t_script = file_handler.render_file_from_template(
+                s, 
+                "script", 
+                output_folder=output_folder
+            )
             export_fp = Path(scripts_folder, s)
             file_handler.add_file(t_script, export_fp)
 

--- a/asreviewcontrib/makita/template_basic.py
+++ b/asreviewcontrib/makita/template_basic.py
@@ -64,9 +64,9 @@ def render_jobs_basic(
             datasets=datasets,
             template_name=template.name
             if template.name == "basic"
-            else "custom",  # NOQA
-            template_name_long=template.name_long,  # NOQA
-            template_scripts=template.scripts,  # NOQA
+            else "custom",
+            template_name_long=template.name_long,
+            template_scripts=template.scripts,
             output_folder=output_folder,
             job_file=job_file,
         )

--- a/asreviewcontrib/makita/template_basic.py
+++ b/asreviewcontrib/makita/template_basic.py
@@ -25,6 +25,7 @@ def render_jobs_basic(
     # initialize file handler
     file_handler = FileHandler()
 
+    # generate params for all simulations
     for i, fp_dataset in enumerate(sorted(datasets)):
         check_filename_dataset(fp_dataset)
 
@@ -41,7 +42,8 @@ def render_jobs_basic(
             }
         )
 
-    # open template TODO@{Replace by more sustainable module}
+    # Instantiate a ConfigTemplate object, initializing a Jinja2 environment and 
+    # setting up template variables and extensions.
     template = ConfigTemplate(fp_template)
 
     # render scripts
@@ -70,8 +72,10 @@ def render_jobs_basic(
         )
         file_handler.add_file(t_docs, s)
 
+    # print summary to console
     file_handler.print_summary()
 
+    # render file and return
     return template.render(
         {
             "datasets": params,

--- a/asreviewcontrib/makita/template_basic.py
+++ b/asreviewcontrib/makita/template_basic.py
@@ -47,14 +47,15 @@ def render_jobs_basic(
     template = ConfigTemplate(fp_template)
 
     # render scripts
-    for s in template.scripts:
-        t_script = file_handler.render_file_from_template(
-            s, 
-            "script", 
-            output_folder=output_folder
-        )
-        export_fp = Path(scripts_folder, s)
-        file_handler.add_file(t_script, export_fp)
+    if template.scripts is not None:
+        for s in template.scripts:
+            t_script = file_handler.render_file_from_template(
+                s, 
+                "script", 
+                output_folder=output_folder
+            )
+            export_fp = Path(scripts_folder, s)
+            file_handler.add_file(t_script, export_fp)
 
     # render docs
     for s in template.docs:

--- a/asreviewcontrib/makita/template_basic.py
+++ b/asreviewcontrib/makita/template_basic.py
@@ -45,7 +45,11 @@ def render_jobs_basic(
     template = ConfigTemplate(fp_template)
 
     for s in template.scripts:
-        t_script = file_handler.render_file_from_template(s, "script")
+        t_script = file_handler.render_file_from_template(
+            s, 
+            "script", 
+            output_folder=output_folder
+        )
         export_fp = Path(scripts_folder, s)
         file_handler.add_file(t_script, export_fp)
 

--- a/asreviewcontrib/makita/template_basic.py
+++ b/asreviewcontrib/makita/template_basic.py
@@ -44,6 +44,7 @@ def render_jobs_basic(
     # open template TODO@{Replace by more sustainable module}
     template = ConfigTemplate(fp_template)
 
+    # render scripts
     for s in template.scripts:
         t_script = file_handler.render_file_from_template(
             s, 
@@ -53,6 +54,7 @@ def render_jobs_basic(
         export_fp = Path(scripts_folder, s)
         file_handler.add_file(t_script, export_fp)
 
+    # render docs
     for s in template.docs:
         t_docs = file_handler.render_file_from_template(
             s,

--- a/asreviewcontrib/makita/template_basic.py
+++ b/asreviewcontrib/makita/template_basic.py
@@ -58,20 +58,21 @@ def render_jobs_basic(
             file_handler.add_file(t_script, export_fp)
 
     # render docs
-    for s in template.docs:
-        t_docs = file_handler.render_file_from_template(
-            s,
-            "doc",
-            datasets=datasets,
-            template_name=template.name
-            if template.name == "basic"
-            else "custom",
-            template_name_long=template.name_long,
-            template_scripts=template.scripts,
-            output_folder=output_folder,
-            job_file=job_file,
-        )
-        file_handler.add_file(t_docs, s)
+    if template.docs is not None:
+        for s in template.docs:
+            t_docs = file_handler.render_file_from_template(
+                s,
+                "doc",
+                datasets=datasets,
+                template_name=template.name
+                if template.name == "basic"
+                else "custom",
+                template_name_long=template.name_long,
+                template_scripts=template.scripts,
+                output_folder=output_folder,
+                job_file=job_file,
+            )
+            file_handler.add_file(t_docs, s)
 
     # print summary to console
     file_handler.print_summary()

--- a/asreviewcontrib/makita/template_multiple_models.py
+++ b/asreviewcontrib/makita/template_multiple_models.py
@@ -58,14 +58,15 @@ def render_jobs_multiple_models(
     template = ConfigTemplate(fp_template)
 
     # render scripts
-    for s in template.scripts:
-        t_script = file_handler.render_file_from_template(
-            s, 
-            "script", 
-            output_folder=output_folder
-        )
-        export_fp = Path(scripts_folder, s)
-        file_handler.add_file(t_script, export_fp)
+    if template.scripts is not None:
+        for s in template.scripts:
+            t_script = file_handler.render_file_from_template(
+                s, 
+                "script", 
+                output_folder=output_folder
+            )
+            export_fp = Path(scripts_folder, s)
+            file_handler.add_file(t_script, export_fp)
 
     # render docs
     for s in template.docs:

--- a/asreviewcontrib/makita/template_multiple_models.py
+++ b/asreviewcontrib/makita/template_multiple_models.py
@@ -75,9 +75,9 @@ def render_jobs_multiple_models(
             datasets=datasets,
             template_name=template.name
             if template.name == "multiple_models"
-            else "custom",  # NOQA
-            template_name_long=template.name_long,  # NOQA
-            template_scripts=template.scripts,  # NOQA
+            else "custom",
+            template_name_long=template.name_long,
+            template_scripts=template.scripts,
             output_folder=output_folder,
             job_file=job_file,
         )

--- a/asreviewcontrib/makita/template_multiple_models.py
+++ b/asreviewcontrib/makita/template_multiple_models.py
@@ -1,4 +1,4 @@
-"""Render basic template."""
+"""Render multiple_models template."""
 
 from pathlib import Path
 

--- a/asreviewcontrib/makita/template_multiple_models.py
+++ b/asreviewcontrib/makita/template_multiple_models.py
@@ -37,6 +37,7 @@ def render_jobs_multiple_models(
     # initialize file handler
     file_handler = FileHandler()
 
+    # generate params for all simulations
     for i, fp_dataset in enumerate(sorted(datasets)):
         check_filename_dataset(fp_dataset)
 
@@ -52,7 +53,8 @@ def render_jobs_multiple_models(
             }
         )
 
-    # open template TODO@{Replace by more sustainable module}
+    # Instantiate a ConfigTemplate object, initializing a Jinja2 environment and 
+    # setting up template variables and extensions.
     template = ConfigTemplate(fp_template)
 
     # render scripts
@@ -81,8 +83,10 @@ def render_jobs_multiple_models(
         )
         file_handler.add_file(t_docs, s)
 
+    # print summary to console
     file_handler.print_summary()
 
+    # render file and return
     return template.render(
         {
             "datasets": params,

--- a/asreviewcontrib/makita/template_multiple_models.py
+++ b/asreviewcontrib/makita/template_multiple_models.py
@@ -51,7 +51,11 @@ def render_jobs_multiple_models(
     template = ConfigTemplate(fp_template)
 
     for s in template.scripts:
-        t_script = file_handler.render_file_from_template(s, "script")
+        t_script = file_handler.render_file_from_template(
+            s, 
+            "script", 
+            output_folder=output_folder
+        )
         export_fp = Path(scripts_folder, s)
         file_handler.add_file(t_script, export_fp)
 

--- a/asreviewcontrib/makita/template_multiple_models.py
+++ b/asreviewcontrib/makita/template_multiple_models.py
@@ -22,7 +22,6 @@ def render_jobs_multiple_models(
     fp_template=None,
     job_file="jobs.sh",
 ):
-
     if all_classifiers is None:
         all_classifiers = ["logistic", "nb", "rf", "svm"]
 

--- a/asreviewcontrib/makita/template_multiple_models.py
+++ b/asreviewcontrib/makita/template_multiple_models.py
@@ -69,20 +69,21 @@ def render_jobs_multiple_models(
             file_handler.add_file(t_script, export_fp)
 
     # render docs
-    for s in template.docs:
-        t_docs = file_handler.render_file_from_template(
-            s,
-            "doc",
-            datasets=datasets,
-            template_name=template.name
-            if template.name == "multiple_models"
-            else "custom",
-            template_name_long=template.name_long,
-            template_scripts=template.scripts,
-            output_folder=output_folder,
-            job_file=job_file,
-        )
-        file_handler.add_file(t_docs, s)
+    if template.docs is not None:
+        for s in template.docs:
+            t_docs = file_handler.render_file_from_template(
+                s,
+                "doc",
+                datasets=datasets,
+                template_name=template.name
+                if template.name == "multiple_models"
+                else "custom",
+                template_name_long=template.name_long,
+                template_scripts=template.scripts,
+                output_folder=output_folder,
+                job_file=job_file,
+            )
+            file_handler.add_file(t_docs, s)
 
     # print summary to console
     file_handler.print_summary()

--- a/asreviewcontrib/makita/template_multiple_models.py
+++ b/asreviewcontrib/makita/template_multiple_models.py
@@ -8,10 +8,6 @@ from asreviewcontrib.makita import __version__
 from asreviewcontrib.makita.utils import FileHandler
 from asreviewcontrib.makita.utils import check_filename_dataset
 
-ALL_CLASSIFIERS = ["logistic", "nb", "rf", "svm"]
-ALL_FEATURE_EXTRACTORS = ["doc2vec", "sbert", "tfidf"]
-IMPOSSIBLE_MODELS = ["nb,doc2vec", "nb,sbert"]
-
 
 def render_jobs_multiple_models(
     datasets,
@@ -20,12 +16,22 @@ def render_jobs_multiple_models(
     scripts_folder="scripts",
     init_seed=535,
     model_seed=165,
-    all_classifiers=ALL_CLASSIFIERS,
-    all_feature_extractors=ALL_FEATURE_EXTRACTORS,
-    impossible_models=IMPOSSIBLE_MODELS,
+    all_classifiers=None,
+    all_feature_extractors=None,
+    impossible_models=None,
     fp_template=None,
     job_file="jobs.sh",
 ):
+
+    if all_classifiers is None:
+        all_classifiers = ["logistic", "nb", "rf", "svm"]
+
+    if all_feature_extractors is None:
+        all_feature_extractors = ["doc2vec", "sbert", "tfidf"]
+
+    if impossible_models is None:
+        impossible_models = ["nb,doc2vec", "nb,sbert"]
+
     """Render jobs."""
     params = []
 

--- a/asreviewcontrib/makita/template_multiple_models.py
+++ b/asreviewcontrib/makita/template_multiple_models.py
@@ -50,6 +50,7 @@ def render_jobs_multiple_models(
     # open template TODO@{Replace by more sustainable module}
     template = ConfigTemplate(fp_template)
 
+    # render scripts
     for s in template.scripts:
         t_script = file_handler.render_file_from_template(
             s, 
@@ -59,6 +60,7 @@ def render_jobs_multiple_models(
         export_fp = Path(scripts_folder, s)
         file_handler.add_file(t_script, export_fp)
 
+    # render docs
     for s in template.docs:
         t_docs = file_handler.render_file_from_template(
             s,

--- a/asreviewcontrib/makita/templates/script_merge_descriptives.py.template
+++ b/asreviewcontrib/makita/templates/script_merge_descriptives.py.template
@@ -53,12 +53,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "-s",
         type=str,
-        default="output/simulation/*/descriptives/",
+        default="{{ output_folder }}/simulation/*/descriptives/",
         help="Datasets location")
     parser.add_argument(
         "-o",
         type=str,
-        default="output/tables/data_descriptives_all.csv",
+        default="{{ output_folder }}/tables/data_descriptives_all.csv",
         help="Output table location")
     args = parser.parse_args()
 

--- a/asreviewcontrib/makita/templates/script_merge_metrics.py.template
+++ b/asreviewcontrib/makita/templates/script_merge_metrics.py.template
@@ -58,12 +58,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "-s",
         type=str,
-        default="output/simulation/*/metrics/",
+        default="{{ output_folder }}/simulation/*/metrics/",
         help="states location")
     parser.add_argument(
         "-o",
         type=str,
-        default="output/tables/metrics_sim_all.csv",
+        default="{{ output_folder }}/tables/metrics_sim_all.csv",
         help="Output table location")
     args = parser.parse_args()
 

--- a/asreviewcontrib/makita/templates/script_merge_tds.py.template
+++ b/asreviewcontrib/makita/templates/script_merge_tds.py.template
@@ -56,12 +56,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "-s",
         type=str,
-        default="{{ output_folder }}/simulation/*/metrics/",
+        required=True,
         help="metrics location")
     parser.add_argument(
         "-o",
         type=str,
-        default="{{ output_folder }}/tables/tds_sim_all.csv",
+        required=True,
         help="Output table location")
     args = parser.parse_args()
 

--- a/asreviewcontrib/makita/templates/script_merge_tds.py.template
+++ b/asreviewcontrib/makita/templates/script_merge_tds.py.template
@@ -56,12 +56,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "-s",
         type=str,
-        default="output/simulation/*/metrics/",
+        default="{{ output_folder }}/simulation/*/metrics/",
         help="metrics location")
     parser.add_argument(
         "-o",
         type=str,
-        default="output/tables/tds_sim_all.csv",
+        default="{{ output_folder }}/tables/tds_sim_all.csv",
         help="Output table location")
     args = parser.parse_args()
 

--- a/asreviewcontrib/makita/templates/template_arfi.txt.template
+++ b/asreviewcontrib/makita/templates/template_arfi.txt.template
@@ -56,6 +56,6 @@ python {{ scripts_folder }}/merge_tds.py -s {{ output_folder }}/simulation/{{ da
 {% endfor %}
 
 # Merge descriptives and metrics
-python {{ scripts_folder }}/merge_descriptives.py -s {{ output_folder }}/simulation/*/descriptives/ -o {{ output_folder }}/tables/data_descriptives_all.csv
-python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/*/metrics/ -o {{ output_folder }}/tables/metrics_sim_all.csv
+python {{ scripts_folder }}/merge_descriptives.py
+python {{ scripts_folder }}/merge_metrics.py
 

--- a/asreviewcontrib/makita/templates/template_basic.txt.template
+++ b/asreviewcontrib/makita/templates/template_basic.txt.template
@@ -58,6 +58,6 @@ python {{ scripts_folder }}/merge_tds.py -s {{ output_folder }}/simulation/{{ da
 {% endfor %}
 
 # Merge descriptives and metrics
-python {{ scripts_folder }}/merge_descriptives.py -s {{ output_folder }}/simulation/*/descriptives/ -o {{ output_folder }}/tables/data_descriptives_all.csv
-python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/*/metrics/ -o {{ output_folder }}/tables/metrics_sim_all.csv
+python {{ scripts_folder }}/merge_descriptives.py
+python {{ scripts_folder }}/merge_metrics.py
 

--- a/asreviewcontrib/makita/templates/template_multiple_models.txt.template
+++ b/asreviewcontrib/makita/templates/template_multiple_models.txt.template
@@ -64,6 +64,6 @@ python {{ scripts_folder }}/merge_tds.py -s {{ output_folder }}/simulation/{{ da
 {% endfor %}
 
 # Merge descriptives and metrics
-python {{ scripts_folder }}/merge_descriptives.py -s {{ output_folder }}/simulation/*/descriptives/ -o {{ output_folder }}/tables/data_descriptives_all.csv
-python {{ scripts_folder }}/merge_metrics.py -s {{ output_folder }}/simulation/*/metrics/ -o {{ output_folder }}/tables/metrics_sim_all.csv
+python {{ scripts_folder }}/merge_descriptives.py
+python {{ scripts_folder }}/merge_metrics.py
 

--- a/asreviewcontrib/makita/utils.py
+++ b/asreviewcontrib/makita/utils.py
@@ -7,12 +7,24 @@ from asreviewcontrib.makita.config import TEMPLATES_FP
 
 
 class FileHandler:
+    """
+    The FileHandler class handles file operations such as adding files and rendering 
+    scripts.
+    """
+
     def __init__(self):
         self.overwrite_all = False
         self.total_files = 0
 
     def add_file(self, content, export_fp):
-        # Check if the file already exists
+        """
+        Add a file to the specified directory.
+
+        Args:
+        content (str): The content to be written into the file.
+        export_fp (Path): A Path object that specifies the directory where the file should be added.
+        """
+
         def allow_overwrite():
             response = input(f"Overwrite {export_fp} ([Y]es/[N]o/[A]ll)? ").lower()
             if response in ["y", "yes"]:
@@ -42,9 +54,25 @@ class FileHandler:
             self.total_files += 1
 
     def print_summary(self):
+        """
+        Print the total number of files created by the FileHandler object.
+        """
+        
         print(f"{self.total_files} file(s) created.")
 
     def render_file_from_template(self, name, file_type, **kwargs):
+        """
+        Render a file from a template.
+
+        Args:
+        name (str): The name of the file to be rendered.
+        file_type (str): The type of the file to be rendered.
+        kwargs: Additional keyword arguments.
+
+        Returns:
+        str: The content of the file rendered from the template.
+        """
+
         params = {
             "version": __version__,
         }
@@ -59,5 +87,15 @@ class FileHandler:
 
 
 def check_filename_dataset(fp):
+    """
+    Check if the filename of the dataset contains any whitespace.
+
+    Args:
+    fp (str): The file path of the dataset.
+
+    Raises:
+    ValueError: If the filename of the dataset contains whitespace.
+    """
+
     if " " in Path(fp).stem:
         raise ValueError(f"Dataset filename '{fp}' cannot contain whitespace.")

--- a/asreviewcontrib/makita/utils.py
+++ b/asreviewcontrib/makita/utils.py
@@ -22,7 +22,8 @@ class FileHandler:
 
         Args:
         content (str): The content to be written into the file.
-        export_fp (Path): A Path object that specifies the directory where the file should be added.
+        export_fp (Path): A Path object that specifies the directory where the file 
+        should be added.
         """
 
         def allow_overwrite():
@@ -57,7 +58,7 @@ class FileHandler:
         """
         Print the total number of files created by the FileHandler object.
         """
-        
+
         print(f"{self.total_files} file(s) created.")
 
     def render_file_from_template(self, name, file_type, **kwargs):


### PR DESCRIPTION
uses yaml to update the output folder in the scripts so they don't have to be specified in the last lines of the template