### PR TITLE
Add platform support to Makita

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -40,6 +40,7 @@ jobs:
         asreview makita template multiple_models | tee output.txt
         grep -q "ERROR" output.txt && exit 1 || true
     - name: Run ShellCheck
+      if: ${{ matrix.os != 'windows-latest' }}
       uses: ludeeus/action-shellcheck@master
       with:
         scandir: './tmp'

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -2,8 +2,10 @@ name: test-suite
 on: [push, pull_request]
 jobs:
   test-template-and-lint:
-    name: test-templates-and-scripts
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@master
     - uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -72,15 +72,20 @@ sh jobs.sh
 
 The `jobs.sh` script is a shell script that runs all jobs in the project folder.
 
-### Windows support
+### Platform support
 
-For Windows users, ASReview Makita offers support for batch files. Use the `-f` option to generate a `jobs.bat` script instead of the default `jobs.sh` script.
+By default, ASReview Makita renders job files for the platform of rendering. It is possible to render jobs for other platforms as well. Use the argument `--platform` with values "Windows", "Linux", or "Darwin" (MacOS) to change the output.
 
 ```console
-asreview makita template basic -f jobs.bat
+asreview makita template basic --platform Windows
 ```
 
-> Alternatively, Windows CMD does not support the `sh` command, and a bash shell is required. You can use tools such as Git Bash, Cygwin, WSL, etc. to run the `jobs.sh` script instead.
+By default, the job file depends on the platform. Windows users will see a `jobs.bat` file, while other users will see `jobs.sh`. You can overwrite this with
+
+```console
+asreview makita template basic --job_file my_jobs_file.my_ext
+```
+
 
 ## Templates
 
@@ -203,7 +208,7 @@ Use `-s`  (source) and `-o` (output) to tweak paths.
 
 Some scripts are added automatically to the folder, as they are part of the
 template. For example, the `get_plot.py` script is added to the generated folder
-when using any template, as it is used to generate the plots. 
+when using any template, as it is used to generate the plots.
 
 Still, `get_plot.py` can be used on its own, as it is a standalone script. To use it,
 use `-s` (source) and `-o` (output) to tweak paths.

--- a/asreviewcontrib/makita/template_arfi.py
+++ b/asreviewcontrib/makita/template_arfi.py
@@ -1,5 +1,7 @@
 """Render ARFI template."""
 
+import os
+import platform
 from pathlib import Path
 
 import numpy as np
@@ -46,9 +48,16 @@ def render_jobs_arfi(
     init_seed=535,
     model_seed=165,
     fp_template=None,
-    job_file="jobs.sh",
+    job_file=None,
+    platform_sys=None,
 ):
     """Render jobs."""
+
+    if not platform_sys:
+        platform_sys = platform.system()
+    if not job_file:
+        job_file = "jobs.bat" if os.name == "nt" else "jobs.sh"
+
     params = []
 
     # initialize file handler
@@ -104,6 +113,7 @@ def render_jobs_arfi(
             "init_seed": init_seed,
             "output_folder": output_folder,
             "scripts_folder": scripts_folder,
+            "platform": platform_sys,
             "version": __version__,
         }
     )

--- a/asreviewcontrib/makita/template_basic.py
+++ b/asreviewcontrib/makita/template_basic.py
@@ -1,5 +1,7 @@
 """Render basic template."""
 
+import os
+import platform
 from pathlib import Path
 
 from cfgtemplater.config_template import ConfigTemplate
@@ -18,8 +20,15 @@ def render_jobs_basic(
     model_seed=165,
     fp_template=None,
     job_file=None,
+    platform_sys=None,
 ):
     """Render jobs."""
+
+    if not platform_sys:
+        platform_sys = platform.system()
+    if not job_file:
+        job_file = "jobs.bat" if os.name == "nt" else "jobs.sh"
+
     params = []
 
     # initialize file handler
@@ -71,6 +80,7 @@ def render_jobs_basic(
             "datasets": params,
             "output_folder": output_folder,
             "scripts_folder": scripts_folder,
+            "platform_sys": platform_sys,
             "version": __version__,
         }
     )

--- a/asreviewcontrib/makita/template_multiple_models.py
+++ b/asreviewcontrib/makita/template_multiple_models.py
@@ -1,5 +1,7 @@
 """Render basic template."""
 
+import os
+import platform
 from pathlib import Path
 
 from cfgtemplater.config_template import ConfigTemplate
@@ -24,9 +26,16 @@ def render_jobs_multiple_models(
     all_feature_extractors=ALL_FEATURE_EXTRACTORS,
     impossible_models=IMPOSSIBLE_MODELS,
     fp_template=None,
-    job_file="jobs.sh",
+    job_file=None,
+    platform_sys=None,
 ):
     """Render jobs."""
+
+    if not platform_sys:
+        platform_sys = platform.system()
+    if not job_file:
+        job_file = "jobs.bat" if os.name == "nt" else "jobs.sh"
+
     params = []
 
     # initialize file handler
@@ -78,6 +87,7 @@ def render_jobs_multiple_models(
             "output_folder": output_folder,
             "n_runs": n_runs,
             "scripts_folder": scripts_folder,
+            "platform": platform_sys,
             "version": __version__,
             "all_classifiers": all_classifiers,
             "all_feature_extractors": all_feature_extractors,


### PR DESCRIPTION

### Platform support

By default, ASReview Makita renders job files for the platform of rendering. It is possible to render jobs for other platforms as well. Use the argument `--platform` with values "Windows", "Linux", or "Darwin" (MacOS) to change the output.

```console
asreview makita template basic --platform Windows
```

By default, the job file depends on the platform. Windows users will see a `jobs.bat` file, while other users will see `jobs.sh`. You can overwrite this with

```console
asreview makita template basic --job_file my_jobs_file.my_ext
```