### PR TITLE
Fix no legend error message, and duplicate labels

### DIFF
--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -27,7 +27,19 @@ from asreviewcontrib.insights.plot import plot_recall
 
 
 def get_plot_from_states(states, filename, legend=None):
-    """Generate an ASReview plot from state files."""
+    """Generate an ASReview plot from state files.
+    
+    Arguments
+    ---------
+    states: list
+        List of state files.
+    filename: str
+        Filename of the plot.
+    legend: str
+        Add a legend to the plot, based on the given parameter.
+        Possible values: "filename", "model", "feature_extraction",
+        "balance_strategy", "query_strategy", "classifier".
+    """
 
     # sort the states alphabetically
     states = sorted(states)
@@ -78,7 +90,8 @@ def get_plot_from_states(states, filename, legend=None):
                     labels.append(label)
 
     # add legend to plot
-    ax.legend(loc=4, prop={'size': 8})
+    if legend:
+        ax.legend(loc=4, prop={'size': 8})
 
     # save plot
     fig.savefig(str(filename))

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -26,7 +26,7 @@ from asreview import open_state
 from asreviewcontrib.insights.plot import plot_recall
 
 
-def _set_legend(ax, state, legend_option, labels, state_file):
+def _set_legend(ax, state, legend_option, label_to_line, state_file):
     metadata = state.settings_metadata
     label = None
 
@@ -46,9 +46,15 @@ def _set_legend(ax, state, legend_option, labels, state_file):
         except KeyError:
             raise ValueError(f"Invalid legend setting: '{legend_option}'")
 
-    if label and label not in labels:
-        ax.lines[-2].set_label(label)
-        labels.append(label)
+    if label:
+        # add label to line
+        if label not in label_to_line:
+            ax.lines[-2].set_label(label)
+            label_to_line[label] = ax.lines[-2]
+        # set color of line to the color of the first line with the same label
+        else:
+            ax.lines[-2].set_color(label_to_line[label].get_color())
+            ax.lines[-2].set_label("_no_legend_")
 
 
 def get_plot_from_states(states, filename, legend=None):
@@ -67,13 +73,13 @@ def get_plot_from_states(states, filename, legend=None):
     """
     states = sorted(states)
     fig, ax = plt.subplots()
-    labels = []
+    label_to_line = {}
 
     for state_file in states:
         with open_state(state_file) as state:
             plot_recall(ax, state)
             if legend:
-                _set_legend(ax, state, legend, labels, state_file)
+                _set_legend(ax, state, legend, label_to_line, state_file)
 
     if legend:
         ax.legend(loc=4, prop={'size': 8})

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -43,8 +43,8 @@ def _set_legend(ax, state, legend_option, label_to_line, state_file):
     else:
         try:
             label = metadata["settings"][legend_option]
-        except KeyError:
-            raise ValueError(f"Invalid legend setting: '{legend_option}'")
+        except KeyError as err:
+            raise ValueError(f"Invalid legend setting: '{legend_option}'") from err  # noqa: E501
 
     if label:
         # add label to line
@@ -59,7 +59,7 @@ def _set_legend(ax, state, legend_option, label_to_line, state_file):
 
 def get_plot_from_states(states, filename, legend=None):
     """Generate an ASReview plot from state files.
-    
+
     Arguments
     ---------
     states: list

--- a/asreviewcontrib/makita/templates/script_get_plot.py.template
+++ b/asreviewcontrib/makita/templates/script_get_plot.py.template
@@ -26,6 +26,31 @@ from asreview import open_state
 from asreviewcontrib.insights.plot import plot_recall
 
 
+def _set_legend(ax, state, legend_option, labels, state_file):
+    metadata = state.settings_metadata
+    label = None
+
+    if legend_option == "filename":
+        label = state_file.stem
+    elif legend_option == "model":
+        label = " - ".join(
+            [metadata["settings"]["model"],
+             metadata["settings"]["feature_extraction"],
+             metadata["settings"]["balance_strategy"],
+             metadata["settings"]["query_strategy"]])
+    elif legend_option == "classifier":
+        label = metadata["settings"]["model"]
+    else:
+        try:
+            label = metadata["settings"][legend_option]
+        except KeyError:
+            raise ValueError(f"Invalid legend setting: '{legend_option}'")
+
+    if label and label not in labels:
+        ax.lines[-2].set_label(label)
+        labels.append(label)
+
+
 def get_plot_from_states(states, filename, legend=None):
     """Generate an ASReview plot from state files.
     
@@ -40,60 +65,18 @@ def get_plot_from_states(states, filename, legend=None):
         Possible values: "filename", "model", "feature_extraction",
         "balance_strategy", "query_strategy", "classifier".
     """
-
-    # sort the states alphabetically
     states = sorted(states)
-
     fig, ax = plt.subplots()
-
     labels = []
 
     for state_file in states:
         with open_state(state_file) as state:
-            # draw the plot
             plot_recall(ax, state)
+            if legend:
+                _set_legend(ax, state, legend, labels, state_file)
 
-            # settings for legend "filename"
-            if legend == "filename":
-                ax.lines[-2].set_label(state_file.stem)
-                ax.legend(loc=4, prop={'size': 8})
-            # settings for legend "settings"
-            elif legend:
-                metadata = state.settings_metadata
-
-                # settings for legend "model"
-                if legend == "model":
-                    label = " - ".join(
-                            [metadata["settings"]["model"],
-                             metadata["settings"]["feature_extraction"],
-                             metadata["settings"]["balance_strategy"],
-                             metadata["settings"]["query_strategy"]])
-                    
-                # settings for legend "classifier"
-                elif legend == "classifier":
-                    label = metadata["settings"]["model"]
-
-                # settings for legend from metadata
-                else:
-                    try:
-                        label = metadata["settings"][legend]
-                    except KeyError as exc:
-                        raise ValueError(
-                            f"Legend setting '{legend}' "
-                            "not found in state file settings."
-                        ) from exc
-                    
-                # add label to legend if not already present 
-                # (multiple states can have the same label)
-                if label not in labels:
-                    ax.lines[-2].set_label(label)
-                    labels.append(label)
-
-    # add legend to plot
     if legend:
         ax.legend(loc=4, prop={'size': 8})
-
-    # save plot
     fig.savefig(str(filename))
 
 


### PR DESCRIPTION
Currently, when no legend is selected you'll get an error message. This PR will prevent this from happening. Also includes better handling of duplicate labels by assigning them the same color.