### PR TITLE
Update pyproject.toml to bump asreview version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12"
 ]
 license = {text = "MIT"}
-dependencies = ["asreview>=1,<2", "jinja2", "cfgtemplater"]
+dependencies = ["asreview>=1.3,<2", "jinja2", "cfgtemplater"]
 dynamic = ["version"]
 requires-python = ">=3.7"
 


### PR DESCRIPTION
`_entry_points` is not available below 1.3